### PR TITLE
:recycle: fix compression syntaxes issues

### DIFF
--- a/src/Mindee/Input/LocalInputSource.cs
+++ b/src/Mindee/Input/LocalInputSource.cs
@@ -153,13 +153,14 @@ namespace Mindee.Input
         /// <param name="forceSourceText">Whether to force the operation on PDFs with source text. This will attempt to
         /// re-render PDF text over the rasterized original. If disabled, ignored the operation.
         /// WARNING: this operation is strongly discouraged.</param>
+        /// <param name="disableSourceText">If the PDF has source text, whether to re-apply it to the original or not.</param>
         public void Compress(int quality = 85, int? maxWidth = null, int? maxHeight = null,
-            bool forceSourceText = false)
+            bool forceSourceText = false, bool disableSourceText = true)
 
         {
             if (IsPdf())
             {
-                this.FileBytes = PdfCompressor.CompressPdf(this.FileBytes, quality, forceSourceText);
+                this.FileBytes = PdfCompressor.CompressPdf(this.FileBytes, quality, forceSourceText, disableSourceText);
 
             }
             else

--- a/src/Mindee/Pdf/PdfCompressor.cs
+++ b/src/Mindee/Pdf/PdfCompressor.cs
@@ -14,7 +14,7 @@ namespace Mindee.Pdf
     /// <summary>
     /// Image compressor static class to handle PDF compression.
     /// </summary>
-    public static partial class PdfCompressor
+    public static class PdfCompressor
     {
         /// <summary>
         /// Compresses a PDF file using DocLib.
@@ -219,7 +219,7 @@ namespace Mindee.Pdf
             {
                 try
                 {
-                    // Files will result in a failure to read from PDF, but can still be valid, so we try from Skiasharp.
+                    // Image files will result in a failure to read from PDF, but can still be valid, so we try from Skiasharp.
                     using var original = SKBitmap.Decode(fileBytes);
                     return false;
                 }

--- a/tests/Mindee.UnitTests/Input/LocalInputSourceTest.cs
+++ b/tests/Mindee.UnitTests/Input/LocalInputSourceTest.cs
@@ -212,9 +212,9 @@ namespace Mindee.UnitTests.Input
         {
             lock (DocLib.Instance)
             {
-                var initialWithtext = new LocalInputSource("Resources/file_types/pdf/multipage.pdf");
-                var compressedWithText = PdfCompressor.CompressPdf(initialWithtext.FileBytes, 100, true, false);
-                using var originalReader = DocLib.Instance.GetDocReader(initialWithtext.FileBytes, new PageDimensions(1));
+                var initialWithText = new LocalInputSource("Resources/file_types/pdf/multipage.pdf");
+                var compressedWithText = PdfCompressor.CompressPdf(initialWithText.FileBytes, 100, true, false);
+                using var originalReader = DocLib.Instance.GetDocReader(initialWithText.FileBytes, new PageDimensions(1));
                 using var compressedReader = DocLib.Instance.GetDocReader(compressedWithText, new PageDimensions(1));
                 Assert.Equal(originalReader.GetPageCount(), compressedReader.GetPageCount());
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
* :memo: fix docstring
* :recycle: remove useless 'partial' keyword
* :recycle: fix test names
* :recycle: add missing boolean parameter to LocalInputSource.Compress()

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
