### PR TITLE
:recycle: harmonise platform names with other client libs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,7 +37,9 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
+            7.0.x
             8.0.x
+            9.0.x
 
       - name: Install dependencies
         run: |
@@ -77,7 +79,9 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
+            7.0.x
             8.0.x
+            9.0.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -7,40 +7,4 @@ on:
 
 jobs:
   tag-version:
-    runs-on: ubuntu-latest
-    if: "contains(github.event.head_commit.message, ':bookmark:')"
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: '0'
-
-    - name: Tag version
-      run: |
-        msg_start=':bookmark: Version '
-        version_format='[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}'
-        version=$(git log -1 --skip=0 --pretty=%s | grep -oP "(?<=${msg_start})${version_format}")
-        
-        if [ -z "${version}" ]; then
-          echo 'Version not found, aborting.'
-          exit 1
-        fi
-        
-        echo "Found version: ${version}";
-        tag="v${version}";
-        
-        echo "Would tag: ${tag}";
-        existing_tag=$(git tag -l "${tag}");
-
-        if [ "${existing_tag}" ]; then
-          echo "Tag '${existing_tag}' already exists, aborting.";
-          exit 1;
-        fi
-
-        git config user.name "Mindee";
-        git config user.email "opensource@mindee.com"
-        
-        git tag -a "${tag}" -m"Version ${version}";
-        git push origin "${tag}"
-        
-        echo "Tagged and pushed: ${tag}"
+    uses: mindee/client-lib-actions/.github/workflows/tag-version.yml@main

--- a/.github/workflows/test-sample-codes.yml
+++ b/.github/workflows/test-sample-codes.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-22.04"
-        dotnet-version:
+        dotnet:
           - "net6.0"
           - "net7.0"
           - "net8.0"
@@ -32,7 +32,9 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
+          7.0.x
           8.0.x
+          9.0.x
 
 #    - uses: actions/cache@v4
 #      with:
@@ -58,7 +60,7 @@ jobs:
 
     - name: Publish Locally
       run: |
-        dotnet pack "src/Mindee" -p:TargetFrameworks=${{ matrix.dotnet-version }} --output ./dist
+        dotnet pack "src/Mindee" -p:TargetFrameworks=${{ matrix.dotnet }} --output ./dist
         cd ./dist
         dotnet nuget push *.nupkg --source "NugetLocal"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
         os:
           - "ubuntu-22.04"
           - "macos-13"
-        dotnet-version:
+        dotnet:
           - "net6.0"
           - "net7.0"
           - "net8.0"
@@ -24,53 +24,13 @@ jobs:
 
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
+      id: setup-step
       with:
         dotnet-version: |
           6.0.x
+          7.0.x
           8.0.x
-
-    - uses: actions/cache@v4
-      with:
-        path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-
-    - name: Install dependencies
-      run: |
-        dotnet restore
-
-    - name: Build
-      run: |
-        dotnet build -f ${{ matrix.dotnet-version }} --no-restore
-
-    - name: Test
-      run: |
-        dotnet test -f ${{ matrix.dotnet-version }} --no-restore --verbosity normal "tests\Mindee.UnitTests"
-
-  test-windows:
-    name: Test on Windows
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        dotnet-version:
-          - "net472"
-          - "net482"
-          - "net6.0"
-          - "net7.0"
-          - "net8.0"
-    runs-on: "windows-2022"
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: Set up .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: |
-          6.0.x
-          8.0.x
+          9.0.x
 
     - uses: actions/cache@v4
       with:
@@ -85,4 +45,46 @@ jobs:
 
     - name: Build and test
       run: |
-        dotnet test -f ${{ matrix.dotnet-version }} --no-restore --verbosity normal "tests\Mindee.UnitTests"
+        dotnet test -f ${{ matrix.dotnet }} --no-restore --verbosity normal "tests\Mindee.UnitTests"
+
+  test-windows:
+    name: Test on Windows
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        dotnet:
+          - "net472"
+          - "net482"
+          - "net6.0"
+          - "net7.0"
+          - "net8.0"
+    runs-on: "windows-2022"
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v4
+      id: setup-step
+      with:
+        dotnet-version: |
+          6.0.x
+          7.0.x
+          8.0.x
+          9.0.x
+
+    - uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Install dependencies
+      run: |
+        dotnet restore
+
+    - name: Build and test
+      run: |
+        dotnet test -f ${{ matrix.dotnet }} --no-restore --verbosity normal "tests\Mindee.UnitTests"

--- a/src/Mindee/ServiceCollectionsExtensions.cs
+++ b/src/Mindee/ServiceCollectionsExtensions.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Net;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Mindee.Http;
 using Mindee.Pdf;
@@ -60,9 +59,18 @@ namespace Mindee.Extensions.DependencyInjection
 
         private static string BuildUserAgent()
         {
+            string platform;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                platform = "windows";
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                platform = "linux";
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                platform = "macos";
+            else
+                platform = "other";
             return $"mindee-api-dotnet@v{Assembly.GetExecutingAssembly().GetName().Version}"
                    + $" dotnet-v{Environment.Version}"
-                   + $" {Environment.OSVersion}";
+                   + $" {platform}";
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Make sure all client libs return the same names for platforms.

Had to add .NET 7.0, 9.0 to installed versions otherwise tests would not run :shrug: .


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
