### PR TITLE
:recycle: :boom: harmonize PDF page options

### DIFF
--- a/src/Mindee/Extraction/PdfExtractor.cs
+++ b/src/Mindee/Extraction/PdfExtractor.cs
@@ -82,7 +82,7 @@ namespace Mindee.Extraction
 
                 var splitQuery = new SplitQuery(
                     SourcePdf,
-                    new PageOptions(pageIndexElem.ConvertAll(item => (short)(item + 1)).ToArray()));
+                    new PageOptions(pageIndexElem.ConvertAll(item => (short)item).ToArray()));
                 var pdfOperation = new DocNetApi(new NullLogger<DocNetApi>());
                 var mergedPdfBytes = pdfOperation.Split(splitQuery).File;
                 extractedPdfs.Add(new ExtractedPdf(mergedPdfBytes, fieldFilename));

--- a/src/Mindee/Input/PageOptions.cs
+++ b/src/Mindee/Input/PageOptions.cs
@@ -12,13 +12,13 @@ namespace Mindee.Input
         /// A negative index can be used, indicating an offset from the end of the document.
         /// [1, -1] represents the first and last pages of the document.
         /// </summary>
-        public short[] PageNumbers { get; }
+        public short[] PageIndexes { get; }
 
         /// <summary>
         /// <see cref="Input.PageOptionsOperation"/>
         /// </summary>
         /// <remarks>KeepOnly by default.</remarks>
-        public PageOptionsOperation PageOptionsOperation { get; }
+        public PageOptionsOperation Operation { get; }
 
         /// <summary>
         /// Apply the operation only if the document has at least this many pages.
@@ -29,17 +29,17 @@ namespace Mindee.Input
         /// <summary>
         ///
         /// </summary>
-        /// <param name="pageNumbers"><see cref="PageNumbers"/></param>
-        /// <param name="pageOptionsOperation"><see cref="PageOptionsOperation"/></param>
-        /// <param name="onMinPages"><see cref="PageOptionsOperation"/></param>
+        /// <param name="pageIndexes"><see cref="PageIndexes"/></param>
+        /// <param name="operation"><see cref="Operation"/></param>
+        /// <param name="onMinPages"><see cref="Operation"/></param>
         public PageOptions(
-            short[] pageNumbers
-            , PageOptionsOperation pageOptionsOperation = PageOptionsOperation.KeepOnly
+            short[] pageIndexes
+            , PageOptionsOperation operation = PageOptionsOperation.KeepOnly
             , ushort onMinPages = 0
             )
         {
-            PageNumbers = pageNumbers;
-            PageOptionsOperation = pageOptionsOperation;
+            PageIndexes = pageIndexes;
+            Operation = operation;
             OnMinPages = onMinPages;
         }
 
@@ -49,8 +49,8 @@ namespace Mindee.Input
         /// <returns></returns>
         public override string ToString()
         {
-            string pageNumbers = String.Join(", ", PageNumbers);
-            return $"min: {OnMinPages}, operation: {PageOptionsOperation}, pages: ({pageNumbers})";
+            string pageNumbers = String.Join(", ", PageIndexes);
+            return $"min: {OnMinPages}, operation: {Operation}, pages: ({pageNumbers})";
         }
     }
 }

--- a/src/Mindee/Pdf/DocNetApi.cs
+++ b/src/Mindee/Pdf/DocNetApi.cs
@@ -37,14 +37,14 @@ namespace Mindee.Pdf
                 return new SplitPdf(splitQuery.File, totalPages);
             }
 
-            var targetedRange = splitQuery.PageOptions.PageNumbers.Select(pn =>
+            var targetedRange = splitQuery.PageOptions.PageIndexes.Select(pageIndex =>
             {
-                if (pn < 0)
+                if (pageIndex < 0)
                 {
-                    return (totalPages - System.Math.Abs(pn));
+                    return (totalPages - System.Math.Abs(pageIndex));
                 }
 
-                return pn;
+                return pageIndex + 1;
             }).ToArray();
 
             if (targetedRange.Count() > totalPages)
@@ -53,18 +53,18 @@ namespace Mindee.Pdf
                     $"The total indexes of pages to cut is superior to the total page count of the file ({totalPages}).");
             }
 
-            if (targetedRange.Any(pn => pn > totalPages || pn <= 0))
+            if (targetedRange.Any(pageIndex => pageIndex > totalPages || pageIndex <= 0))
             {
                 throw new ArgumentOutOfRangeException(
-                    $"Some indexes ({string.Join(",", splitQuery.PageOptions.PageNumbers)}) do not exist in the file ({totalPages} pages).");
+                    $"Some indexes ({string.Join(",", splitQuery.PageOptions.PageIndexes)}) do not exist in the file ({totalPages} pages).");
             }
 
             string range;
-            if (splitQuery.PageOptions.PageOptionsOperation == PageOptionsOperation.KeepOnly)
+            if (splitQuery.PageOptions.Operation == PageOptionsOperation.KeepOnly)
             {
                 range = string.Join(",", targetedRange);
             }
-            else if (splitQuery.PageOptions.PageOptionsOperation == PageOptionsOperation.Remove)
+            else if (splitQuery.PageOptions.Operation == PageOptionsOperation.Remove)
             {
                 var pageIndiceOriginalDocument = Enumerable.Range(1, totalPages);
                 range = string.Join(",", pageIndiceOriginalDocument.Where(v => !targetedRange.Contains(v)));
@@ -72,7 +72,7 @@ namespace Mindee.Pdf
             else
             {
                 throw new InvalidOperationException(
-                    $"This operation is not available ({splitQuery.PageOptions.PageOptionsOperation}).");
+                    $"This operation is not available ({splitQuery.PageOptions.Operation}).");
             }
 
             lock (DocLib.Instance)

--- a/tests/Mindee.UnitTests/Input/LocalInputSourceTest.cs
+++ b/tests/Mindee.UnitTests/Input/LocalInputSourceTest.cs
@@ -127,7 +127,7 @@ namespace Mindee.UnitTests.Input
         public void Image_Resize_From_InputSource()
         {
             var imageResizeInput = new LocalInputSource("Resources/file_types/receipt.jpg");
-            imageResizeInput.Compress(75, 250, 1000);
+            imageResizeInput.Compress(maxWidth: 250, maxHeight: 1000);
             File.WriteAllBytes("Resources/output/resize_indirect.jpg", imageResizeInput.FileBytes);
             var initialFileInfo = new FileInfo("Resources/file_types/receipt.jpg");
             var renderedFileInfo = new FileInfo("Resources/output/resize_indirect.jpg");
@@ -171,7 +171,7 @@ namespace Mindee.UnitTests.Input
         public void Pdf_Compress_From_InputSource()
         {
             var pdfResizeInput = new LocalInputSource("Resources/products/invoice_splitter/default_sample.pdf");
-            pdfResizeInput.Compress(75);
+            pdfResizeInput.Compress(quality: 75);
             File.WriteAllBytes("Resources/output/resize_indirect.pdf", pdfResizeInput.FileBytes);
             var initialFileInfo = new FileInfo("Resources/products/invoice_splitter/default_sample.pdf");
             var renderedFileInfo = new FileInfo("Resources/output/resize_indirect.pdf");
@@ -237,10 +237,43 @@ namespace Mindee.UnitTests.Input
         }
 
         [Fact]
-        public void ApplyPageOperation_Should_Work()
+        public void ApplyPageOperation_KeepFirstPage_Should_Work()
+        {
+            var inputSource = new LocalInputSource("Resources/file_types/pdf/multipage.pdf");
+            var pageOptions = new PageOptions(
+                operation: PageOptionsOperation.KeepOnly
+                , pageIndexes: new short[] { 0 });
+            inputSource.ApplyPageOptions(pageOptions);
+        }
+
+        [Fact]
+        public void ApplyPageOperation_Keep5FirstPages_Should_Work()
         {
             var initialWithText = new LocalInputSource("Resources/file_types/pdf/multipage.pdf");
-            initialWithText.ApplyPageOptions(new PageOptions(new short[] { 1, 2 }));
+            // Only for documents having 10 or more pages:
+            // Remove the first 5 pages
+            var pageOptions = new PageOptions(
+                operation: PageOptionsOperation.Remove,
+                onMinPages: 10,
+                pageIndexes: new short[] { 0, 1, 2, 3, 4 }
+            );
+
+            initialWithText.ApplyPageOptions(pageOptions);
+        }
+
+        [Fact]
+        public void ApplyPageOperation_Keep3VariousPages_Should_Work()
+        {
+            var initialWithText = new LocalInputSource("Resources/file_types/pdf/multipage.pdf");
+
+            // Only for documents having 2 or more pages:
+            // Keep only these pages: first, penultimate, last
+            var pageOptions = new PageOptions(
+                operation: PageOptionsOperation.KeepOnly,
+                onMinPages: 2,
+                pageIndexes: new short[] { 0, -2, -1 }
+            );
+            initialWithText.ApplyPageOptions(pageOptions);
         }
     }
 }

--- a/tests/Mindee.UnitTests/MindeeClientTest.cs
+++ b/tests/Mindee.UnitTests/MindeeClientTest.cs
@@ -245,7 +245,7 @@ namespace Mindee.UnitTests
 
             var inputSource = new LocalInputSource(new FileInfo("Resources/file_types/pdf/multipage.pdf"));
             Assert.Equal(12, inputSource.GetPageCount());
-            var pageOptions = new PageOptions(pageNumbers: new short[] { 1, 2, 3 });
+            var pageOptions = new PageOptions(pageIndexes: new short[] { 1, 2, 3 });
             var response = await mindeeClient.ParseAsync<InvoiceV4>(
                 inputSource, pageOptions: pageOptions);
 

--- a/tests/Mindee.UnitTests/Pdf/PdfOperationTest.cs
+++ b/tests/Mindee.UnitTests/Pdf/PdfOperationTest.cs
@@ -20,7 +20,7 @@ namespace Mindee.UnitTests.Domain.Pdf
         {
             var splitQuery = new SplitQuery(
                 File.ReadAllBytes("Resources/file_types/pdf/multipage.pdf"),
-                new PageOptions(new short[] { 2 }));
+                new PageOptions(new short[] { 1 }));
 
             var splitPdf = _pdfOperation.Split(splitQuery);
 
@@ -35,7 +35,7 @@ namespace Mindee.UnitTests.Domain.Pdf
         {
             var splitQuery = new SplitQuery(File.ReadAllBytes(
                 "Resources/file_types/pdf/multipage.pdf"),
-                new PageOptions(new short[] { 1, 2 }));
+                new PageOptions(new short[] { 0, 1 }));
 
             var splitPdf = _pdfOperation.Split(splitQuery);
 
@@ -48,20 +48,9 @@ namespace Mindee.UnitTests.Domain.Pdf
         [Trait("Category", "PDF operations")]
         public void Split_WantsTooManyPages_MustFail()
         {
+            var pageOptions = new PageOptions(new short[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 });
             var splitQuery = new SplitQuery(File.ReadAllBytes(
-                "Resources/file_types/pdf/multipage.pdf"),
-                new PageOptions(new short[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }));
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => _pdfOperation.Split(splitQuery));
-        }
-
-        [Fact]
-        [Trait("Category", "PDF operations")]
-        public void Split_WantsStartPageTo0_MustFail()
-        {
-            var splitQuery = new SplitQuery(File.ReadAllBytes(
-                "Resources/file_types/pdf/multipage.pdf"),
-                new PageOptions(new short[] { 0, 1, 2, 3 }));
+                "Resources/file_types/pdf/multipage.pdf"), pageOptions);
 
             Assert.Throws<ArgumentOutOfRangeException>(() => _pdfOperation.Split(splitQuery));
         }
@@ -72,7 +61,7 @@ namespace Mindee.UnitTests.Domain.Pdf
         {
             var splitQuery = new SplitQuery(File.ReadAllBytes(
                 "Resources/file_types/receipt.jpga"),
-                new PageOptions(new short[] { 1, 2, 3 }));
+                new PageOptions(new short[] { 0, 1, 2 }));
 
             Assert.Throws<MindeeException>(() => _pdfOperation.Split(splitQuery));
         }
@@ -83,7 +72,7 @@ namespace Mindee.UnitTests.Domain.Pdf
         {
             var splitQuery = new SplitQuery(File.ReadAllBytes(
                 "Resources/file_types/pdf/multipage.pdf"),
-                new PageOptions(new short[] { 1, -2, -1 }));
+                new PageOptions(new short[] { 0, -2, -1 }));
 
             var splitPdf = _pdfOperation.Split(splitQuery);
 
@@ -99,7 +88,7 @@ namespace Mindee.UnitTests.Domain.Pdf
             var splitQuery = new SplitQuery(
                 File.ReadAllBytes("Resources/file_types/pdf/multipage.pdf")
                 , new PageOptions(
-                    new short[] { 1, 2, 3 }
+                    new short[] { 0, 1, 2 }
                     , PageOptionsOperation.Remove));
 
             var splitPdf = _pdfOperation.Split(splitQuery);
@@ -116,7 +105,7 @@ namespace Mindee.UnitTests.Domain.Pdf
             var splitQuery = new SplitQuery(
                 File.ReadAllBytes("Resources/file_types/pdf/multipage_cut-2.pdf")
                 , new PageOptions(
-                    new short[] { 1 }
+                    new short[] { 0 }
                     , PageOptionsOperation.Remove
                     , 5));
 


### PR DESCRIPTION
## Description
Page Options should have 0-based indexes, just like everybody else does (except Julia).


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
