### PR TITLE
:sparkles: add support for page count & mime type, fix v2 field naming conventions

### DIFF
--- a/src/Mindee/Parsing/V2/Inference.cs
+++ b/src/Mindee/Parsing/V2/Inference.cs
@@ -12,13 +12,13 @@ namespace Mindee.Parsing.V2
         /// ResultModel info.
         /// </summary>
         [JsonPropertyName("model")]
-        public InferenceResultModel Model { get; set; }
+        public InferenceModel Model { get; set; }
 
         /// <summary>
         /// ResultFile info.
         /// </summary>
         [JsonPropertyName("file")]
-        public InferenceResultFile File { get; set; }
+        public InferenceFile File { get; set; }
 
         /// <summary>
         /// The model result values.

--- a/src/Mindee/Parsing/V2/InferenceFile.cs
+++ b/src/Mindee/Parsing/V2/InferenceFile.cs
@@ -6,7 +6,7 @@ namespace Mindee.Parsing.V2
     /// <summary>
     /// ResultFile info for V2 API.
     /// </summary>
-    public class InferenceResultFile
+    public class InferenceFile
     {
         /// <summary>
         /// ResultFile name.
@@ -21,6 +21,18 @@ namespace Mindee.Parsing.V2
         public string Alias { get; set; }
 
         /// <summary>
+        /// Page count.
+        /// </summary>
+        [JsonPropertyName("page_count")]
+        public int PageCount { get; set; }
+
+        /// <summary>
+        /// MIME type.
+        /// </summary>
+        [JsonPropertyName("mime_type")]
+        public string MimeType { get; set; }
+
+        /// <summary>
         /// Pretty-prints the file section exactly as expected by Inference.ToString().
         /// </summary>
         public override string ToString()
@@ -28,6 +40,8 @@ namespace Mindee.Parsing.V2
             var sb = new StringBuilder("File\n====");
             sb.Append($"\n:Name: {Name}");
             sb.Append($"\n:Alias: {Alias}");
+            sb.Append($"\n:Page Count: {PageCount}");
+            sb.Append($"\n:MIME Type: {MimeType}");
             return sb.ToString();
         }
 

--- a/src/Mindee/Parsing/V2/InferenceModel.cs
+++ b/src/Mindee/Parsing/V2/InferenceModel.cs
@@ -6,7 +6,7 @@ namespace Mindee.Parsing.V2
     /// <summary>
     /// ResultModel information for a V2 API inference.
     /// </summary>
-    public class InferenceResultModel
+    public class InferenceModel
     {
         /// <summary>
         /// The Mindee ID of the model.

--- a/src/Mindee/Parsing/V2/Job.cs
+++ b/src/Mindee/Parsing/V2/Job.cs
@@ -71,6 +71,6 @@ namespace Mindee.Parsing.V2
         /// Webhooks.
         /// </summary>
         [JsonPropertyName("webhooks")]
-        public List<Webhook> Webhooks { get; set; }
+        public List<JobWebhook> Webhooks { get; set; }
     }
 }

--- a/src/Mindee/Parsing/V2/JobWebhook.cs
+++ b/src/Mindee/Parsing/V2/JobWebhook.cs
@@ -4,9 +4,9 @@ using System.Text.Json.Serialization;
 namespace Mindee.Parsing.V2
 {
     /// <summary>
-    /// Webhook info response for the V2 API.
+    /// Webhook info response for jobs in the V2 API.
     /// </summary>
-    public class Webhook
+    public class JobWebhook
     {
         /// <summary>
         /// Date and time the webhook was created at.

--- a/tests/Mindee.UnitTests/Parsing/V2/InferenceV2Test.cs
+++ b/tests/Mindee.UnitTests/Parsing/V2/InferenceV2Test.cs
@@ -66,6 +66,11 @@ namespace Mindee.UnitTests.Parsing.V2
             Assert.Equal("USA", fields["supplier_address"].ObjectField.Fields["country"].ToString());
 
             Assert.NotNull(fields["supplier_address"].ToString());
+            var file = response.Inference.File;
+            Assert.Equal("complete.jpg", file.Name);
+            Assert.Equal(1, file.PageCount);
+            Assert.Equal("image/jpeg", file.MimeType);
+            Assert.Null(file.Alias);
         }
 
 
@@ -123,6 +128,7 @@ namespace Mindee.UnitTests.Parsing.V2
             Assert.NotNull(fields["field_object"].ObjectField);
             Assert.NotNull(fields["field_simple_list"].ListField);
             Assert.NotNull(fields["field_object_list"].ListField);
+
         }
 
         [Fact(DisplayName = "standard_field_types.json - simple / object / list variants must be recognised")]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
* :sparkles: add support for page count & mime type metadata
* :recycle: fix field class names for V2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
