### PR TITLE
:sparkles: allow comparing field confidence score

### DIFF
--- a/src/Mindee/Parsing/V2/Field/FieldConfidence.cs
+++ b/src/Mindee/Parsing/V2/Field/FieldConfidence.cs
@@ -4,7 +4,6 @@ using Mindee.Input;
 
 namespace Mindee.Parsing.V2.Field
 {
-
     /// <summary>
     /// Confidence level of a field as returned by the V2 API.
     /// </summary>
@@ -19,19 +18,18 @@ namespace Mindee.Parsing.V2.Field
     {
         /// <summary>100 % confidence.</summary>
         [EnumMember(Value = "Certain")]
-        Certain,
+        Certain = 4,
 
         /// <summary>Very high confidence.</summary>
         [EnumMember(Value = "High")]
-        High,
+        High = 3,
 
         /// <summary>Medium confidence.</summary>
         [EnumMember(Value = "Medium")]
-        Medium,
+        Medium = 2,
 
         /// <summary>Low confidence.</summary>
         [EnumMember(Value = "Low")]
-        Low
+        Low = 1
     }
-
 }

--- a/tests/Mindee.UnitTests/Parsing/V2/InferenceV2Test.cs
+++ b/tests/Mindee.UnitTests/Parsing/V2/InferenceV2Test.cs
@@ -140,10 +140,13 @@ namespace Mindee.UnitTests.Parsing.V2
             Assert.NotNull(inference);
             InferenceFields fields = inference.Result.Fields;
 
-            Assert.NotNull(fields["field_simple_string"].SimpleField);
-            string fieldSimpleStringValue = fields["field_simple_string"].SimpleField.Value;
+            SimpleField fieldSimpleString = fields["field_simple_string"].SimpleField;
+            Assert.NotNull(fieldSimpleString);
+            string fieldSimpleStringValue = fieldSimpleString.Value;
             Assert.Equal("field_simple_string-value", fieldSimpleStringValue);
-            Assert.Equal(FieldConfidence.Certain, fields["field_simple_string"].SimpleField.Confidence);
+            Assert.Equal(FieldConfidence.Certain, fieldSimpleString.Confidence);
+            Assert.Equal(4, (int?)fieldSimpleString.Confidence);
+            Assert.True((int?)fieldSimpleString.Confidence >= (int)FieldConfidence.Medium);
 
             Assert.NotNull(fields["field_simple_float"].SimpleField);
             Double fieldSimpleFloatValue = fields["field_simple_float"].SimpleField.Value;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Make it possible to compare field confidences numerically.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
