### PR TITLE
:sparkles: add support for V2 crop and split file operations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
 
   <!-- Common packages for all frameworks -->
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+    <PackageReference Include="SkiaSharp" Version="3.119.2" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.1" />
     <PackageReference Include="Docnet.Core" Version="2.6.0" />
   </ItemGroup>

--- a/src/Mindee/Extraction/ImageExtractor.cs
+++ b/src/Mindee/Extraction/ImageExtractor.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Docnet.Core;
+using Docnet.Core.Models;
+using Mindee.Geometry;
+using Mindee.Image;
+using Mindee.Input;
+using SkiaSharp;
+
+namespace Mindee.Extraction
+{
+    /// <summary>
+    ///     Extract sub-images from an image.
+    /// </summary>
+    public class ImageExtractor
+    {
+        /// <summary>
+        /// Name of the file.
+        /// </summary>
+        protected readonly string _filename;
+        /// <summary>
+        /// List of SKBitmap representing the pages of the file.
+        /// </summary>
+        private readonly List<SKBitmap> _pageImages;
+        /// <summary>
+        /// Format to save the resulting images as.
+        /// </summary>
+        protected readonly string SaveFormat;
+
+        /// <summary>
+        ///     LocalInputSource object used by the ImageExtractor.
+        /// </summary>
+        public readonly LocalInputSource LocalInput;
+
+        /// <summary>
+        ///     Init from a Local Input Source.
+        /// </summary>
+        /// <param name="localInput">Locally loaded resource.</param>
+        /// <param name="saveFormat">Format to save the resulting images as.</param>
+        public ImageExtractor(LocalInputSource localInput, string saveFormat = null)
+        {
+            _filename = localInput.Filename;
+            _pageImages = [];
+            LocalInput = localInput;
+            if (saveFormat == null)
+            {
+                var extension = Path.GetExtension(localInput.Filename)?.Substring(1);
+                if (extension != null && !extension.Equals("pdf", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    SaveFormat = extension;
+                }
+                else
+                {
+                    SaveFormat = "jpg";
+                }
+            }
+            else
+            {
+                SaveFormat = saveFormat;
+            }
+
+            if (localInput.IsPdf())
+            {
+                var pdfPageImages = PdfToImages(localInput.FileBytes);
+                _pageImages.AddRange(pdfPageImages);
+            }
+            else
+            {
+                _pageImages.Add(SKBitmap.Decode(localInput.FileBytes));
+            }
+        }
+
+        /// <summary>
+        ///     Init from a path.
+        /// </summary>
+        /// <param name="filePath">Path to the file.</param>
+        public ImageExtractor(string filePath) : this(new LocalInputSource(filePath))
+        {
+        }
+
+        /// <summary>
+        ///     Renders the input Pdf's pages as individual images.
+        /// </summary>
+        /// <param name="fileBytes">Input pdf.</param>
+        /// <returns>A list of pages, as SKBitmap.</returns>
+        private static List<SKBitmap> PdfToImages(byte[] fileBytes)
+        {
+            var images = new List<SKBitmap>();
+            lock (DocLib.Instance)
+            {
+                using var docReader = DocLib.Instance.GetDocReader(fileBytes, new PageDimensions(1));
+                for (var i = 0; i < docReader.GetPageCount(); i++)
+                {
+                    using var pageReader = docReader.GetPageReader(i);
+                    var width = pageReader.GetPageWidth();
+                    var height = pageReader.GetPageHeight();
+                    var bytes = pageReader.GetImage();
+                    var bmp = ImageUtils.ArrayToImage(ImageUtils.ConvertTo3DArray(bytes, width, height));
+                    images.Add(bmp);
+                }
+
+                return images;
+            }
+        }
+
+        /// <summary>
+        ///     Splits the filename into name and extension.
+        /// </summary>
+        protected static string[] SplitNameStrict(string filename)
+        {
+            return
+            [
+                Path.GetFileNameWithoutExtension(filename),
+                Path.GetExtension(filename).TrimStart('.')
+            ];
+        }
+
+        /// <summary>
+        ///     Gets the number of pages in the file.
+        /// </summary>
+        /// <returns>The number of pages in the file.</returns>
+        public int GetPageCount()
+        {
+            return _pageImages.Count;
+        }
+
+        /// <summary>
+        /// Extracts a single image from a field having position data.
+        /// </summary>
+        /// <param name="bbox">Bounding box of the field.</param>
+        /// <param name="pageIndex">Index of the page containing the field.</param>
+        /// <returns>Extracted image as an SKBitmap.</returns>
+        protected SKBitmap ExtractImage(Bbox bbox, int pageIndex)
+        {
+            var image = _pageImages[pageIndex];
+            var width = image.Width;
+            var height = image.Height;
+            var minX = (int)Math.Round(bbox.MinX * width);
+            var maxX = (int)Math.Round(bbox.MaxX * width);
+            var minY = (int)Math.Round(bbox.MinY * height);
+            var maxY = (int)Math.Round(bbox.MaxY * height);
+
+            var croppedBitmap = new SKBitmap(maxX - minX, maxY - minY);
+            using var canvas = new SKCanvas(croppedBitmap);
+            var destRect = new SKRect(0, 0, croppedBitmap.Width, croppedBitmap.Height);
+            var sourceRect = new SKRect(minX, minY, maxX, maxY);
+            canvas.DrawBitmap(image, sourceRect, destRect);
+
+            return croppedBitmap;
+        }
+
+        /// <summary>
+        /// Extracts multiple images from a field having position data.
+        /// </summary>
+        /// <param name="pageId">The page index to extract, begins at 0.</param>
+        /// <param name="polygons">The list of polygons representing the position data.</param>
+        /// <returns>A list of extracted images.</returns>
+        public List<ExtractedImage> ExtractMultipleImagesFromSource(int pageId, List<Polygon> polygons)
+        {
+            var filename = this.LocalInput.Filename;
+            var extractedImages = new List<ExtractedImage>();
+            foreach (var polygon in polygons)
+            {
+                var bbox = Utils.BboxFromPolygon(polygon);
+                var fieldFilename = $"{filename}_{pageId:D3}_{polygons.IndexOf(polygon):D3}.{SaveFormat}";
+                extractedImages.Add(new ExtractedImage(ExtractImage(bbox, pageId), fieldFilename, SaveFormat));
+            }
+            return extractedImages;
+        }
+    }
+}

--- a/src/Mindee/Extraction/ImageExtractor.cs
+++ b/src/Mindee/Extraction/ImageExtractor.cs
@@ -160,11 +160,13 @@ namespace Mindee.Extraction
         {
             var filename = this.LocalInput.Filename;
             var extractedImages = new List<ExtractedImage>();
+            int i = 0;
             foreach (var polygon in polygons)
             {
                 var bbox = Utils.BboxFromPolygon(polygon);
-                var fieldFilename = $"{filename}_{pageId:D3}_{polygons.IndexOf(polygon):D3}.{SaveFormat}";
-                extractedImages.Add(new ExtractedImage(ExtractImage(bbox, pageId), fieldFilename, SaveFormat));
+                var fieldFilename = $"{filename}_page{pageId}-{polygons.IndexOf(polygon)}.{SaveFormat}";
+                extractedImages.Add(new ExtractedImage(ExtractImage(bbox, pageId), fieldFilename, SaveFormat, pageId, i));
+                i++;
             }
             return extractedImages;
         }

--- a/src/Mindee/Extraction/PdfExtractor.cs
+++ b/src/Mindee/Extraction/PdfExtractor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Docnet.Core;
 using Microsoft.Extensions.Logging.Abstractions;
+using Mindee.Exceptions;
 using Mindee.Input;
 using Mindee.Pdf;
 using SkiaSharp;
@@ -89,7 +90,7 @@ namespace Mindee.Extraction
             {
                 if (pageIndexElem.Count == 0)
                 {
-                    throw new ArgumentException("Empty indexes not allowed for extraction.");
+                    throw new MindeeInputException("Empty indexes not allowed for extraction.");
                 }
 
                 var extension = Path.GetExtension(LocalInput.Filename);

--- a/src/Mindee/Extraction/PdfExtractor.cs
+++ b/src/Mindee/Extraction/PdfExtractor.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Docnet.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Mindee.Input;
+using Mindee.Pdf;
+using SkiaSharp;
+
+namespace Mindee.Extraction
+{
+    /// <summary>
+    ///     PDF extraction class.
+    /// </summary>
+    public class PdfExtractor
+    {
+        /// <summary>
+        /// Local input source.
+        /// </summary>
+        protected readonly LocalInputSource LocalInput;
+
+        /// <summary>
+        /// Source PDF bytes.
+        /// </summary>
+        protected byte[] SourcePdf;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="PdfExtractor" /> class.
+        /// </summary>
+        /// <param name="localInput">Instance of a LocalInputSource, provided by the user.</param>
+        public PdfExtractor(LocalInputSource localInput)
+        {
+            LocalInput = localInput;
+        }
+
+        /// <summary>
+        ///     Wrapper for PDF GetPageCount();
+        /// </summary>
+        /// <returns>The number of pages in the file.</returns>
+        public int GetPageCount()
+        {
+            return LocalInput.GetPageCount();
+        }
+
+        /// <summary>
+        /// Extract the PDF bytes.
+        /// </summary>
+        /// <returns></returns>
+        protected byte[] PdfBytes()
+        {
+            if (SourcePdf != null)
+            {
+                return this.SourcePdf;
+            }
+            if (LocalInput.IsPdf())
+            {
+                SourcePdf = LocalInput.FileBytes;
+            }
+            else
+            {
+                var memoryStream = new MemoryStream();
+                using var image = SKImage.FromEncodedData(LocalInput.FileBytes);
+                using var bmp = SKBitmap.FromImage(image);
+                var pageSize = new SKSize(bmp.Width, bmp.Height);
+                using (var document = SKDocument.CreatePdf(memoryStream))
+                {
+                    var canvas = document.BeginPage(pageSize.Width, pageSize.Height);
+                    canvas.DrawBitmap(bmp, SKPoint.Empty);
+                    document.EndPage();
+                }
+
+                SourcePdf = memoryStream.ToArray();
+            }
+
+            return SourcePdf;
+        }
+
+        /// <summary>
+        ///     Extracts sub-documents from the source document using list of page indexes.
+        /// </summary>
+        /// <param name="pageIndexes">List of sub-lists of pages to keep.</param>
+        /// <returns>Extracted documents.</returns>
+        /// <exception cref="ArgumentException"></exception>
+        public List<ExtractedPdf> ExtractSubDocuments(List<List<int>> pageIndexes)
+        {
+            var extractedPdfs = new List<ExtractedPdf>();
+
+            foreach (var pageIndexElem in pageIndexes)
+            {
+                if (pageIndexElem.Count == 0)
+                {
+                    throw new ArgumentException("Empty indexes not allowed for extraction.");
+                }
+
+                var extension = Path.GetExtension(LocalInput.Filename);
+                var prefix = Path.GetFileNameWithoutExtension(LocalInput.Filename);
+                var fieldFilename =
+                    $"{prefix}_{pageIndexElem[0] + 1:D3}-{pageIndexElem[pageIndexElem.Count - 1] + 1:D3}{extension}";
+
+                var splitQuery = new SplitQuery(
+                    PdfBytes(),
+                    new PageOptions(pageIndexElem.ConvertAll(item => (short)item).ToArray()));
+                lock (DocLib.Instance)
+                {
+                    var pdfOperation = new DocNetApi(new NullLogger<DocNetApi>());
+                    var mergedPdfBytes = pdfOperation.Split(splitQuery).File;
+                    extractedPdfs.Add(new ExtractedPdf(mergedPdfBytes, fieldFilename));
+                }
+            }
+
+            return extractedPdfs;
+        }
+    }
+}

--- a/src/Mindee/Image/ExtractedImage.cs
+++ b/src/Mindee/Image/ExtractedImage.cs
@@ -42,17 +42,24 @@ namespace Mindee.Image
         ///     Uses the default image format and filename.
         /// </summary>
         /// <param name="outputPath">The output directory (must exist).</param>
-        public void WriteToFile(string outputPath)
+        /// <param name="fileFormat"></param>
+        public void WriteToFile(string outputPath, string fileFormat = null)
         {
-            var imagePath = Path.Combine(outputPath, Filename);
-            var format = GetEncodedImageFormat(_saveFormat);
+            var targetFormat = fileFormat ?? _saveFormat;
+            var format = GetEncodedImageFormat(targetFormat);
 
-            using (var image = SKImage.FromBitmap(Image))
-            using (var data = image.Encode(format, 100))
-            using (var stream = File.OpenWrite(imagePath))
+            var finalFilename = Filename;
+            if (!string.IsNullOrWhiteSpace(fileFormat))
             {
-                data.SaveTo(stream);
+                var nameWithoutExtension = Path.GetFileNameWithoutExtension(Filename);
+                finalFilename = $"{nameWithoutExtension}.{targetFormat.ToLower()}";
             }
+            var imagePath = Path.Combine(outputPath, finalFilename);
+
+            using var image = SKImage.FromBitmap(Image);
+            using var data = image.Encode(format, 100);
+            using var stream = File.OpenWrite(imagePath);
+            data.SaveTo(stream);
         }
 
         /// <summary>
@@ -61,19 +68,18 @@ namespace Mindee.Image
         /// <returns>An instance of <see cref="LocalInputSource" />.</returns>
         public LocalInputSource AsInputSource()
         {
-            using (var image = SKImage.FromBitmap(Image))
-            using (var data = image.Encode(GetEncodedImageFormat(_saveFormat), 100))
-            using (var output = new MemoryStream())
-            {
-                data.SaveTo(output);
-                return new LocalInputSource(output.ToArray(), Filename);
-            }
+            using var image = SKImage.FromBitmap(Image);
+            using var data = image.Encode(GetEncodedImageFormat(_saveFormat), 100);
+            using var output = new MemoryStream();
+            data.SaveTo(output);
+            return new LocalInputSource(output.ToArray(), Filename);
         }
 
-        private SKEncodedImageFormat GetEncodedImageFormat(string saveFormat)
+        private static SKEncodedImageFormat GetEncodedImageFormat(string saveFormat)
         {
             return saveFormat.ToLower() switch
             {
+                "jpg" or "jpeg" => SKEncodedImageFormat.Jpeg,
                 "png" => SKEncodedImageFormat.Png,
                 "bmp" => SKEncodedImageFormat.Bmp,
                 "gif" => SKEncodedImageFormat.Gif,

--- a/src/Mindee/Image/ExtractedImage.cs
+++ b/src/Mindee/Image/ExtractedImage.cs
@@ -15,16 +15,30 @@ namespace Mindee.Image
         private readonly string _saveFormat;
 
         /// <summary>
+        /// Page number the image was extracted from.
+        /// </summary>
+        public int PageId;
+
+        /// <summary>
+        /// ID of the image.
+        /// </summary>
+        public int ElementId;
+
+        /// <summary>
         ///     Initializes a new instance of the <see cref="ExtractedImage" /> class.
         /// </summary>
         /// <param name="image">The extracted image.</param>
         /// <param name="filename">The filename for the image.</param>
         /// <param name="saveFormat">The format to save the image.</param>
-        public ExtractedImage(SKBitmap image, string filename, string saveFormat)
+        /// <param name="pageId">The page number the image was extracted from.</param>
+        /// <param name="elementId">The ID of the image.</param>
+        public ExtractedImage(SKBitmap image, string filename, string saveFormat, int pageId, int elementId)
         {
             Image = image;
             Filename = filename;
             _saveFormat = saveFormat;
+            PageId = pageId;
+            ElementId = elementId;
         }
 
         /// <summary>
@@ -35,29 +49,48 @@ namespace Mindee.Image
         /// <summary>
         ///     Name of the file.
         /// </summary>
-        private string Filename { get; }
+        public string Filename { get; }
 
         /// <summary>
         ///     Writes the image to a file.
-        ///     Uses the default image format and filename.
+        ///     If outputPath has an extension, it is treated as a full file path.
+        ///     Otherwise, it is treated as a directory and uses the default filename.
         /// </summary>
-        /// <param name="outputPath">The output directory (must exist).</param>
-        /// <param name="fileFormat"></param>
-        public void WriteToFile(string outputPath, string fileFormat = null)
+        /// <param name="outputPath">The output directory (must exist) or full file path.</param>
+        /// <param name="quality">The quality of the image. Defaults to 100.</param>
+        /// <param name="fileFormat">The desired format. If null, inferred from extension or default.</param>
+        public void WriteToFile(string outputPath, int quality = 100, string fileFormat = null)
         {
+            string imagePath;
             var targetFormat = fileFormat ?? _saveFormat;
+
+            if (Path.HasExtension(outputPath))
+            {
+                imagePath = outputPath;
+                if (string.IsNullOrWhiteSpace(fileFormat))
+                {
+                    var extension = Path.GetExtension(outputPath).TrimStart('.');
+                    if (!string.IsNullOrWhiteSpace(extension))
+                    {
+                        targetFormat = extension.ToLower();
+                    }
+                }
+            }
+            else
+            {
+                var finalFilename = Filename;
+                if (!string.IsNullOrWhiteSpace(fileFormat))
+                {
+                    var nameWithoutExtension = Path.GetFileNameWithoutExtension(Filename);
+                    finalFilename = $"{nameWithoutExtension}.{targetFormat.ToLower()}";
+                }
+                imagePath = Path.Combine(outputPath, finalFilename);
+            }
+
             var format = GetEncodedImageFormat(targetFormat);
 
-            var finalFilename = Filename;
-            if (!string.IsNullOrWhiteSpace(fileFormat))
-            {
-                var nameWithoutExtension = Path.GetFileNameWithoutExtension(Filename);
-                finalFilename = $"{nameWithoutExtension}.{targetFormat.ToLower()}";
-            }
-            var imagePath = Path.Combine(outputPath, finalFilename);
-
             using var image = SKImage.FromBitmap(Image);
-            using var data = image.Encode(format, 100);
+            using var data = image.Encode(format, quality);
             using var stream = File.OpenWrite(imagePath);
             data.SaveTo(stream);
         }
@@ -65,11 +98,12 @@ namespace Mindee.Image
         /// <summary>
         ///     Returns the image in a format suitable for sending to a client for parsing.
         /// </summary>
+        /// <param name="quality">The quality of the image. Defaults to 100.</param>
         /// <returns>An instance of <see cref="LocalInputSource" />.</returns>
-        public LocalInputSource AsInputSource()
+        public LocalInputSource AsInputSource(int quality = 100)
         {
             using var image = SKImage.FromBitmap(Image);
-            using var data = image.Encode(GetEncodedImageFormat(_saveFormat), 100);
+            using var data = image.Encode(GetEncodedImageFormat(_saveFormat), quality);
             using var output = new MemoryStream();
             data.SaveTo(output);
             return new LocalInputSource(output.ToArray(), Filename);

--- a/src/Mindee/Pdf/ExtractedPdf.cs
+++ b/src/Mindee/Pdf/ExtractedPdf.cs
@@ -1,6 +1,5 @@
 using System.IO;
-using Docnet.Core;
-using Docnet.Core.Models;
+using Mindee.Exceptions;
 using Mindee.Input;
 
 namespace Mindee.Pdf
@@ -11,24 +10,55 @@ namespace Mindee.Pdf
     public class ExtractedPdf
     {
         /// <summary>
-        ///     Name of the original file.
+        /// Loca
+        /// </summary>
+        public readonly LocalInputSource LocalInput;
+
+        /// <summary>
+        /// Page count.
+        /// </summary>
+        public int PageCount { get; set; }
+
+        /// <summary>
+        /// Original filename.
         /// </summary>
         public readonly string Filename;
 
         /// <summary>
-        ///     File object for an ExtractedPdf.
+        ///     Initializes a new instance of the <see cref="ExtractedPdf" /> class.
         /// </summary>
-        public readonly byte[] PdfBytes;
+        /// <param name="fileBytes">A byte array representation of the Pdf.</param>
+        /// <param name="filename">Name of the original file.</param>
+        public ExtractedPdf(byte[] fileBytes, string filename)
+        {
+            var tmpInput = new LocalInputSource(fileBytes, filename);
+            if (tmpInput.IsPdf())
+            {
+                LocalInput = tmpInput;
+            }
+            else
+            {
+                byte[] pdfBytes = PdfUtils.ConvertImageToPdf(fileBytes, filename);
+                string newFilename = Path.ChangeExtension(filename, ".pdf");
+                LocalInput = new LocalInputSource(pdfBytes, newFilename);
+            }
+            PageCount = LocalInput.GetPageCount();
+            Filename = LocalInput.Filename;
+        }
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ExtractedPdf" /> class.
         /// </summary>
-        /// <param name="pdfBytes">A byte array representation of the Pdf.</param>
-        /// <param name="filename">Name of the original file.</param>
-        public ExtractedPdf(byte[] pdfBytes, string filename)
+        /// <param name="localInput">LocalInputSource containing the Pdf bytes and filename.</param>
+        public ExtractedPdf(LocalInputSource localInput)
         {
-            PdfBytes = pdfBytes;
-            Filename = filename;
+            LocalInput = localInput;
+            if (!localInput.IsPdf())
+            {
+                throw new MindeeInputException("The input file is not a PDF.");
+            }
+            PageCount = LocalInput.GetPageCount();
+            Filename = LocalInput.Filename;
         }
 
         /// <summary>
@@ -37,11 +67,7 @@ namespace Mindee.Pdf
         /// <returns>The number of pages in the file.</returns>
         public int GetPageCount()
         {
-            lock (DocLib.Instance)
-            {
-                using var docInstance = DocLib.Instance.GetDocReader(PdfBytes, new PageDimensions(1, 1));
-                return docInstance.GetPageCount();
-            }
+            return LocalInput.GetPageCount();
         }
 
         /// <summary>
@@ -50,13 +76,13 @@ namespace Mindee.Pdf
         /// <param name="outputPath">the output directory (must exist).</param>
         public void WriteToFile(string outputPath)
         {
-            var pdfPath = Path.Combine(outputPath, Filename);
+            var pdfPath = Path.Combine(outputPath, LocalInput.Filename);
             if (Path.GetFileName(outputPath) != string.Empty)
             {
                 pdfPath = Path.GetFullPath(outputPath);
             }
 
-            File.WriteAllBytes(pdfPath, PdfBytes);
+            File.WriteAllBytes(pdfPath, LocalInput.FileBytes);
         }
 
         /// <summary>
@@ -65,7 +91,7 @@ namespace Mindee.Pdf
         /// <returns>an instance of <see cref="ExtractedPdf" /></returns>
         public LocalInputSource AsInputSource()
         {
-            return new LocalInputSource(PdfBytes, Filename);
+            return LocalInput;
         }
     }
 }

--- a/src/Mindee/Pdf/ExtractedPdf.cs
+++ b/src/Mindee/Pdf/ExtractedPdf.cs
@@ -10,7 +10,7 @@ namespace Mindee.Pdf
     public class ExtractedPdf
     {
         /// <summary>
-        /// Loca
+        /// Local input source.
         /// </summary>
         public readonly LocalInputSource LocalInput;
 

--- a/src/Mindee/Pdf/PdfUtils.cs
+++ b/src/Mindee/Pdf/PdfUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using Docnet.Core;
 using Docnet.Core.Models;
@@ -177,6 +178,35 @@ namespace Mindee.Pdf
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Converts an image to a PDF.
+        /// </summary>
+        /// <param name="imageBytes">Raw image bytes.</param>
+        /// <param name="filename">Name of the file.</param>
+        /// <returns></returns>
+        /// <exception cref="MindeeInputException"></exception>
+        public static byte[] ConvertImageToPdf(byte[] imageBytes, string filename)
+        {
+            using var ms = new MemoryStream();
+            using var bitmap = SKBitmap.Decode(imageBytes);
+            if (bitmap == null)
+            {
+                throw new MindeeInputException($"The file {filename} is not a valid image.");
+            }
+
+            using (var document = SKDocument.CreatePdf(ms))
+            {
+                using (var canvas = document.BeginPage(bitmap.Width, bitmap.Height))
+                {
+                    canvas.DrawBitmap(bitmap, 0, 0);
+                    document.EndPage();
+                }
+                document.Close();
+            }
+
+            return ms.ToArray();
         }
     }
 }

--- a/src/Mindee/V1/Extraction/ImageExtractor.cs
+++ b/src/Mindee/V1/Extraction/ImageExtractor.cs
@@ -1,122 +1,35 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
-using Docnet.Core;
-using Docnet.Core.Models;
+using System.Linq;
 using Mindee.Exceptions;
 using Mindee.Geometry;
 using Mindee.Image;
 using Mindee.Input;
 using Mindee.V1.Parsing.Standard;
-using SkiaSharp;
 
 namespace Mindee.V1.Extraction
 {
     /// <summary>
-    ///     Extract sub-images from an image.
+    ///     Legacy V1 Wrapper for ImageExtractor.
     /// </summary>
-    public class ImageExtractor
+    public sealed class ImageExtractor : Mindee.Extraction.ImageExtractor
     {
-        private readonly string _filename;
-        private readonly List<SKBitmap> _pageImages;
-        private readonly string _saveFormat;
-
-        /// <summary>
-        ///     LocalInputSource object used by the ImageExtractor.
-        /// </summary>
-        public readonly LocalInputSource LocalInput;
-
         /// <summary>
         ///     Init from a Local Input Source.
         /// </summary>
         /// <param name="localInput">Locally loaded resource.</param>
         /// <param name="saveFormat">Format to save the resulting images as.</param>
         public ImageExtractor(LocalInputSource localInput, string saveFormat = null)
-        {
-            _filename = localInput.Filename;
-            _pageImages = new List<SKBitmap>();
-            LocalInput = localInput;
-            if (saveFormat == null)
-            {
-                var extension = Path.GetExtension(localInput.Filename)?.Substring(1);
-                if (extension != null && !extension.Equals("pdf", StringComparison.CurrentCultureIgnoreCase))
-                {
-                    _saveFormat = extension;
-                }
-                else
-                {
-                    _saveFormat = "jpg";
-                }
-            }
-            else
-            {
-                _saveFormat = saveFormat;
-            }
-
-            if (localInput.IsPdf())
-            {
-                var pdfPageImages = PdfToImages(localInput.FileBytes);
-                _pageImages.AddRange(pdfPageImages);
-            }
-            else
-            {
-                _pageImages.Add(SKBitmap.Decode(localInput.FileBytes));
-            }
-        }
+            : base(localInput, saveFormat)
+        { }
 
         /// <summary>
         ///     Init from a path.
         /// </summary>
         /// <param name="filePath">Path to the file.</param>
-        public ImageExtractor(string filePath) : this(new LocalInputSource(filePath))
-        {
-        }
+        public ImageExtractor(string filePath)
+            : base(filePath)
+        { }
 
-        /// <summary>
-        ///     Renders the input Pdf's pages as individual images.
-        /// </summary>
-        /// <param name="fileBytes">Input pdf.</param>
-        /// <returns>A list of pages, as SKBitmap.</returns>
-        private static List<SKBitmap> PdfToImages(byte[] fileBytes)
-        {
-            var images = new List<SKBitmap>();
-            lock (DocLib.Instance)
-            {
-                using var docReader = DocLib.Instance.GetDocReader(fileBytes, new PageDimensions(1));
-                for (var i = 0; i < docReader.GetPageCount(); i++)
-                {
-                    using var pageReader = docReader.GetPageReader(i);
-                    var width = pageReader.GetPageWidth();
-                    var height = pageReader.GetPageHeight();
-                    var bytes = pageReader.GetImage();
-                    var bmp = ImageUtils.ArrayToImage(ImageUtils.ConvertTo3DArray(bytes, width, height));
-                    images.Add(bmp);
-                }
-
-                return images;
-            }
-        }
-
-        /// <summary>
-        ///     Splits the filename into name and extension.
-        /// </summary>
-        private static string[] SplitNameStrict(string filename)
-        {
-            return
-            [
-                Path.GetFileNameWithoutExtension(filename),
-                Path.GetExtension(filename).TrimStart('.')
-            ];
-        }
-
-        /// <summary>
-        ///     Gets the number of pages in the file.
-        /// </summary>
-        /// <returns>The number of pages in the file.</returns>
-        public int GetPageCount()
-        {
-            return _pageImages.Count;
-        }
 
         /// <summary>
         ///     Extract multiple images on a given page from a list of fields having position data.
@@ -143,7 +56,7 @@ namespace Mindee.V1.Extraction
             if (GetPageCount() > 1)
             {
                 var splitName = SplitNameStrict(outputName);
-                filename = $"{splitName[0]}.{_saveFormat}";
+                filename = $"{splitName[0]}.{SaveFormat}";
             }
             else
             {
@@ -167,7 +80,7 @@ namespace Mindee.V1.Extraction
             if (GetPageCount() > 1)
             {
                 var splitName = SplitNameStrict(outputName);
-                filename = $"{splitName[0]}.{_saveFormat}";
+                filename = $"{splitName[0]}.{SaveFormat}";
             }
             else
             {
@@ -188,25 +101,15 @@ namespace Mindee.V1.Extraction
             string outputName) where TBaseField : BaseField
         {
             var splitName = SplitNameStrict(outputName);
-            var filename = $"{splitName[0]}_page-{pageIndex + 1:D3}.{_saveFormat}";
+            var filename = $"{splitName[0]}_page-{pageIndex + 1:D3}.{SaveFormat}";
 
-            var extractedImages = new List<ExtractedImage>();
-            for (var i = 0; i < fields.Count; i++)
-            {
-                var extractedImage = ExtractImage(fields[i], pageIndex, i + 1, filename);
-                if (extractedImage != null)
-                {
-                    extractedImages.Add(extractedImage);
-                }
-            }
-
-            return extractedImages;
+            return fields.Select((t, i) => ExtractImage(t, pageIndex, i + 1, filename)).Where(extractedImage => extractedImage != null).ToList();
         }
 
         private List<ExtractedImage> ExtractFromPage(IList<PositionField> fields, int pageIndex, string outputName)
         {
             var splitName = SplitNameStrict(outputName);
-            var filename = $"{splitName[0]}_page-{pageIndex + 1:D3}.{_saveFormat}";
+            var filename = $"{splitName[0]}_page-{pageIndex + 1:D3}.{SaveFormat}";
 
             var extractedImages = new List<ExtractedImage>();
             for (var i = 0; i < fields.Count; i++)
@@ -256,8 +159,8 @@ namespace Mindee.V1.Extraction
             }
 
             var bbox = Utils.BboxFromPolygon(boundingBox);
-            var fieldFilename = $"{splitName[0]}_{index:D3}.{_saveFormat}";
-            return new ExtractedImage(ExtractImage(bbox, pageIndex), fieldFilename, _saveFormat);
+            var fieldFilename = $"{splitName[0]}_{index:D3}.{SaveFormat}";
+            return new ExtractedImage(ExtractImage(bbox, pageIndex), fieldFilename, SaveFormat);
         }
 
         /// <summary>
@@ -283,29 +186,8 @@ namespace Mindee.V1.Extraction
             }
 
             var bbox = Utils.BboxFromPolygon(boundingBox);
-            var fieldFilename = $"{splitName[0]}_{index:D3}.{_saveFormat}";
-            return new ExtractedImage(ExtractImage(bbox, pageIndex), fieldFilename, _saveFormat);
-        }
-
-        private SKBitmap ExtractImage(Bbox bbox, int pageIndex)
-        {
-            var image = _pageImages[pageIndex];
-            var width = image.Width;
-            var height = image.Height;
-            var minX = (int)Math.Round(bbox.MinX * width);
-            var maxX = (int)Math.Round(bbox.MaxX * width);
-            var minY = (int)Math.Round(bbox.MinY * height);
-            var maxY = (int)Math.Round(bbox.MaxY * height);
-
-            var croppedBitmap = new SKBitmap(maxX - minX, maxY - minY);
-            using (var canvas = new SKCanvas(croppedBitmap))
-            {
-                var destRect = new SKRect(0, 0, croppedBitmap.Width, croppedBitmap.Height);
-                var sourceRect = new SKRect(minX, minY, maxX, maxY);
-                canvas.DrawBitmap(image, sourceRect, destRect);
-            }
-
-            return croppedBitmap;
+            var fieldFilename = $"{splitName[0]}_{index:D3}.{SaveFormat}";
+            return new ExtractedImage(ExtractImage(bbox, pageIndex), fieldFilename, SaveFormat);
         }
     }
 }

--- a/src/Mindee/V1/Extraction/ImageExtractor.cs
+++ b/src/Mindee/V1/Extraction/ImageExtractor.cs
@@ -160,7 +160,7 @@ namespace Mindee.V1.Extraction
 
             var bbox = Utils.BboxFromPolygon(boundingBox);
             var fieldFilename = $"{splitName[0]}_{index:D3}.{SaveFormat}";
-            return new ExtractedImage(ExtractImage(bbox, pageIndex), fieldFilename, SaveFormat);
+            return new ExtractedImage(ExtractImage(bbox, pageIndex), fieldFilename, SaveFormat, pageIndex, index);
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace Mindee.V1.Extraction
 
             var bbox = Utils.BboxFromPolygon(boundingBox);
             var fieldFilename = $"{splitName[0]}_{index:D3}.{SaveFormat}";
-            return new ExtractedImage(ExtractImage(bbox, pageIndex), fieldFilename, SaveFormat);
+            return new ExtractedImage(ExtractImage(bbox, pageIndex), fieldFilename, SaveFormat, pageIndex, index);
         }
     }
 }

--- a/src/Mindee/V1/Extraction/PdfExtractor.cs
+++ b/src/Mindee/V1/Extraction/PdfExtractor.cs
@@ -1,102 +1,21 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using Docnet.Core;
-using Docnet.Core.Models;
-using Microsoft.Extensions.Logging.Abstractions;
 using Mindee.Input;
 using Mindee.Pdf;
 using Mindee.V1.Product.InvoiceSplitter;
-using SkiaSharp;
 
 namespace Mindee.V1.Extraction
 {
     /// <summary>
-    ///     PDF extraction class.
+    ///     V1 wrapper for the PDF extraction class.
     /// </summary>
-    public class PdfExtractor
+    public class PdfExtractor : Mindee.Extraction.PdfExtractor
     {
-        private readonly string Filename;
-        private readonly byte[] SourcePdf;
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="PdfExtractor" /> class.
-        /// </summary>
-        /// <param name="localInput">Instance of a LocalInputSource, provided by the user.</param>
-        public PdfExtractor(LocalInputSource localInput)
+        /// <inheritdoc />
+        public PdfExtractor(LocalInputSource localInput) : base(localInput)
         {
-            Filename = localInput.Filename;
-
-            if (localInput.IsPdf())
-            {
-                SourcePdf = localInput.FileBytes;
-            }
-            else
-            {
-                var memoryStream = new MemoryStream();
-                using var image = SKImage.FromEncodedData(localInput.FileBytes);
-                using var bmp = SKBitmap.FromImage(image);
-                var pageSize = new SKSize(bmp.Width, bmp.Height);
-                using (var document = SKDocument.CreatePdf(memoryStream))
-                {
-                    var canvas = document.BeginPage(pageSize.Width, pageSize.Height);
-                    canvas.DrawBitmap(bmp, SKPoint.Empty);
-                    document.EndPage();
-                }
-
-                SourcePdf = memoryStream.ToArray();
-            }
-        }
-
-        /// <summary>
-        ///     Wrapper for pdf GetPageCount();
-        /// </summary>
-        /// <returns>The number of pages in the file.</returns>
-        public int GetPageCount()
-        {
-            lock (DocLib.Instance)
-            {
-                using var docInstance = DocLib.Instance.GetDocReader(SourcePdf, new PageDimensions(1, 1));
-                return docInstance.GetPageCount();
-            }
-        }
-
-        /// <summary>
-        ///     Extracts sub-documents from the source document using list of page indexes.
-        /// </summary>
-        /// <param name="pageIndexes">List of sub-lists of pages to keep.</param>
-        /// <returns>Extracted documents.</returns>
-        /// <exception cref="ArgumentException"></exception>
-        public List<ExtractedPdf> ExtractSubDocuments(List<List<int>> pageIndexes)
-        {
-            var extractedPdfs = new List<ExtractedPdf>();
-
-            foreach (var pageIndexElem in pageIndexes)
-            {
-                if (!pageIndexElem.Any())
-                {
-                    throw new ArgumentException("Empty indexes not allowed for extraction.");
-                }
-
-                var extension = Path.GetExtension(Filename);
-                var prefix = Path.GetFileNameWithoutExtension(Filename);
-                var fieldFilename =
-                    $"{prefix}_{pageIndexElem[0] + 1:D3}-{pageIndexElem[pageIndexElem.Count - 1] + 1:D3}{extension}";
-
-                var splitQuery = new SplitQuery(
-                    SourcePdf,
-                    new PageOptions(pageIndexElem.ConvertAll(item => (short)item).ToArray()));
-                lock (DocLib.Instance)
-                {
-                    var pdfOperation = new DocNetApi(new NullLogger<DocNetApi>());
-                    var mergedPdfBytes = pdfOperation.Split(splitQuery).File;
-                    extractedPdfs.Add(new ExtractedPdf(mergedPdfBytes, fieldFilename));
-                }
-            }
-
-            return extractedPdfs;
         }
 
         /// <summary>

--- a/src/Mindee/V1/Image/ImageExtractor.cs
+++ b/src/Mindee/V1/Image/ImageExtractor.cs
@@ -6,7 +6,7 @@ using Mindee.Image;
 using Mindee.Input;
 using Mindee.V1.Parsing.Standard;
 
-namespace Mindee.V1.Extraction
+namespace Mindee.V1.Image
 {
     /// <summary>
     ///     Legacy V1 Wrapper for ImageExtractor.

--- a/src/Mindee/V1/Image/PdfExtractor.cs
+++ b/src/Mindee/V1/Image/PdfExtractor.cs
@@ -6,7 +6,7 @@ using Mindee.Input;
 using Mindee.Pdf;
 using Mindee.V1.Product.InvoiceSplitter;
 
-namespace Mindee.V1.Extraction
+namespace Mindee.V1.Image
 {
     /// <summary>
     ///     V1 wrapper for the PDF extraction class.

--- a/src/Mindee/V2/FileOperations/Crop.cs
+++ b/src/Mindee/V2/FileOperations/Crop.cs
@@ -48,8 +48,7 @@ namespace Mindee.V2.FileOperations
         {
             var imageExtractor = new ImageExtractor(this._localInput);
             var extractedImages = imageExtractor.ExtractMultipleImagesFromSource(crops[0].Location.Page, crops.Select(c => c.Location.Polygon).ToList());
-
-            return (CropFiles)extractedImages;
+            return new CropFiles(extractedImages);
         }
     }
 }

--- a/src/Mindee/V2/FileOperations/Crop.cs
+++ b/src/Mindee/V2/FileOperations/Crop.cs
@@ -34,7 +34,7 @@ namespace Mindee.V2.FileOperations
         /// <returns></returns>
         public ExtractedImage ExtractSingleCrop(CropItem crop)
         {
-            var polygons = new List<Polygon>() { crop.Location.Polygon };
+            var polygons = new List<Polygon> { crop.Location.Polygon };
             var imageExtractor = new ImageExtractor(this._localInput);
             return imageExtractor.ExtractMultipleImagesFromSource(crop.Location.Page, polygons)[0];
         }

--- a/src/Mindee/V2/FileOperations/Crop.cs
+++ b/src/Mindee/V2/FileOperations/Crop.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+using Mindee.Extraction;
+using Mindee.Geometry;
+using Mindee.Image;
+using Mindee.Input;
+using Mindee.V2.Product.Crop;
+
+namespace Mindee.V2.FileOperations
+{
+    /// <summary>
+    /// V2 Crop operation utility.
+    /// </summary>
+    public sealed class Crop
+    {
+        /// <summary>
+        ///     LocalInputSource object used by the ImageExtractor.
+        /// </summary>
+        private readonly LocalInputSource _localInput;
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="inputSource"></param>
+        public Crop(LocalInputSource inputSource)
+        {
+            this._localInput = inputSource;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="crop"></param>
+        /// <returns></returns>
+        public ExtractedImage ExtractSingleCrop(CropItem crop)
+        {
+            var polygons = new List<Polygon>() { crop.Location.Polygon };
+            var imageExtractor = new ImageExtractor(this._localInput);
+            return imageExtractor.ExtractMultipleImagesFromSource(crop.Location.Page, polygons)[0];
+        }
+
+        /// <summary>
+        /// Extracts multiple crop zones from an image.
+        /// </summary>
+        /// <param name="crops">List of crops.</param>
+        /// <returns></returns>
+        public CropFiles ExtractCrops(List<CropItem> crops)
+        {
+            var imageExtractor = new ImageExtractor(this._localInput);
+            var extractedImages = imageExtractor.ExtractMultipleImagesFromSource(crops[0].Location.Page, crops.Select(c => c.Location.Polygon).ToList());
+
+            return (CropFiles)extractedImages;
+        }
+    }
+}

--- a/src/Mindee/V2/FileOperations/Crop.cs
+++ b/src/Mindee/V2/FileOperations/Crop.cs
@@ -14,7 +14,7 @@ namespace Mindee.V2.FileOperations
     public sealed class Crop
     {
         /// <summary>
-        ///     LocalInputSource object used by the ImageExtractor.
+        ///     LocalInputSource object.
         /// </summary>
         private readonly LocalInputSource _localInput;
 
@@ -28,7 +28,7 @@ namespace Mindee.V2.FileOperations
         }
 
         /// <summary>
-        ///
+        /// Extract a single crop item from a file.
         /// </summary>
         /// <param name="crop"></param>
         /// <returns></returns>
@@ -40,15 +40,20 @@ namespace Mindee.V2.FileOperations
         }
 
         /// <summary>
-        /// Extracts multiple crop zones from an image.
+        /// Extracts multiple crop zones from a file.
         /// </summary>
         /// <param name="crops">List of crops.</param>
         /// <returns></returns>
         public CropFiles ExtractCrops(List<CropItem> crops)
         {
             var imageExtractor = new ImageExtractor(this._localInput);
-            var extractedImages = imageExtractor.ExtractMultipleImagesFromSource(crops[0].Location.Page, crops.Select(c => c.Location.Polygon).ToList());
-            return new CropFiles(extractedImages);
+            CropFiles extractedImages = [];
+            var cropsPerPage = crops.GroupBy(c => c.Location.Page).ToList();
+            foreach (var pageCrops in cropsPerPage)
+            {
+                extractedImages.AddRange(imageExtractor.ExtractMultipleImagesFromSource(pageCrops.Key, pageCrops.Select(c => c.Location.Polygon).ToList()));
+            }
+            return extractedImages;
         }
     }
 }

--- a/src/Mindee/V2/FileOperations/CropFiles.cs
+++ b/src/Mindee/V2/FileOperations/CropFiles.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.IO;
+using Mindee.Image;
+
+namespace Mindee.V2.FileOperations
+{
+    /// <summary>
+    /// Collection of cropped files.
+    /// </summary>
+    public class CropFiles : List<ExtractedImage>
+    {
+        /// <summary>
+        /// Saves all cropped files to disk.
+        /// </summary>
+        /// <param name="path">Path for all files</param>
+        /// <param name="prefix">Prefix for file names</param>
+        /// <param name="fileFormat">File format for saving (default: null)</param>
+        public void SaveAllToDisk(string path, string prefix = "crop", string fileFormat = null)
+        {
+            Directory.CreateDirectory(path);
+
+            int index = 1;
+            foreach (var crop in this)
+            {
+                string fileName = $"{prefix}_{index:D3}.jpg";
+                string filePath = Path.Combine(path, fileName);
+
+                crop.WriteToFile(filePath, fileFormat);
+
+                index++;
+            }
+        }
+    }
+}

--- a/src/Mindee/V2/FileOperations/CropFiles.cs
+++ b/src/Mindee/V2/FileOperations/CropFiles.cs
@@ -10,12 +10,28 @@ namespace Mindee.V2.FileOperations
     public class CropFiles : List<ExtractedImage>
     {
         /// <summary>
+        ///
+        /// </summary>
+        /// <param name="collection"></param>
+        public CropFiles(IEnumerable<ExtractedImage> collection) : base(collection)
+        {
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public CropFiles() : base()
+        {
+        }
+
+        /// <summary>
         /// Saves all cropped files to disk.
         /// </summary>
         /// <param name="path">Path for all files</param>
         /// <param name="prefix">Prefix for file names</param>
+        /// <param name="quality">Quality of the output image</param>
         /// <param name="fileFormat">File format for saving (default: null)</param>
-        public void SaveAllToDisk(string path, string prefix = "crop", string fileFormat = null)
+        public void SaveAllToDisk(string path, int quality = 100, string prefix = "crop", string fileFormat = null)
         {
             Directory.CreateDirectory(path);
 
@@ -25,7 +41,7 @@ namespace Mindee.V2.FileOperations
                 string fileName = $"{prefix}_{index:D3}.jpg";
                 string filePath = Path.Combine(path, fileName);
 
-                crop.WriteToFile(filePath, fileFormat);
+                crop.WriteToFile(filePath, quality, fileFormat);
 
                 index++;
             }

--- a/src/Mindee/V2/FileOperations/Split.cs
+++ b/src/Mindee/V2/FileOperations/Split.cs
@@ -74,10 +74,6 @@ namespace Mindee.V2.FileOperations
         public SplitFiles ExtractSplits(List<List<int>> splits)
         {
             var pdfExtractor = new PdfExtractor(this._localInput);
-            if (splits.Count == 0)
-            {
-                throw new MindeeInputException("No splits provided for extraction.");
-            }
 
             List<List<int>> expandedPageIndexes = [];
             expandedPageIndexes.AddRange(splits.Select(split => ExpandRange(split[0], split[1])));

--- a/src/Mindee/V2/FileOperations/Split.cs
+++ b/src/Mindee/V2/FileOperations/Split.cs
@@ -16,7 +16,7 @@ namespace Mindee.V2.FileOperations
     {
 
         /// <summary>
-        ///     LocalInputSource object used by the ImageExtractor.
+        ///     LocalInputSource object.
         /// </summary>
         private readonly LocalInputSource _localInput;
 

--- a/src/Mindee/V2/FileOperations/Split.cs
+++ b/src/Mindee/V2/FileOperations/Split.cs
@@ -5,6 +5,7 @@ using Mindee.Exceptions;
 using Mindee.Extraction;
 using Mindee.Input;
 using Mindee.Pdf;
+using Mindee.V2.Product.Split;
 
 namespace Mindee.V2.FileOperations
 {
@@ -53,6 +54,16 @@ namespace Mindee.V2.FileOperations
                 string newFilename = Path.ChangeExtension(inputSource.Filename, ".pdf");
                 _localInput = new LocalInputSource(pdfBytes, newFilename);
             }
+        }
+
+        /// <summary>
+        /// Extracts a single split from the input file.
+        /// </summary>
+        /// <param name="splitRange"></param>
+        /// <returns></returns>
+        public ExtractedPdf ExtractSingleSplit(SplitRange splitRange)
+        {
+            return ExtractSplits([splitRange.PageRange])[0];
         }
 
         /// <summary>

--- a/src/Mindee/V2/FileOperations/Split.cs
+++ b/src/Mindee/V2/FileOperations/Split.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+using Mindee.Exceptions;
+using Mindee.Extraction;
+using Mindee.Input;
+
+namespace Mindee.V2.FileOperations
+{
+    /// <summary>
+    /// V2 Split operation utility.
+    /// </summary>
+    public sealed class Split
+    {
+
+        /// <summary>
+        ///     LocalInputSource object used by the ImageExtractor.
+        /// </summary>
+        private readonly LocalInputSource _localInput;
+
+        /// <summary>
+        ///     Expands a range of pages into a list of page indexes.
+        /// </summary>
+        /// <param name="start">Start of the range.</param>
+        /// <param name="end">End of the range.</param>
+        /// <returns>An array of page indexes.</returns>
+        public static List<int> ExpandRange(int start, int end)
+        {
+            if (start > end)
+            {
+                throw new MindeeInputException("Invalid page range provided.");
+            }
+
+            int count = end - start + 1;
+            return Enumerable.Range(start, count).ToList();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="inputSource"></param>
+        public Split(LocalInputSource inputSource)
+        {
+            this._localInput = inputSource;
+        }
+
+        /// <summary>
+        /// Extracts the splits from the input file.
+        /// </summary>
+        /// <param name="splits">List of subpage indexes to keep.</param>
+        /// <returns></returns>
+        public SplitFiles ExtractSplits(List<List<int>> splits)
+        {
+            var pdfExtractor = new PdfExtractor(this._localInput);
+            if (splits.Count == 0)
+            {
+                throw new MindeeInputException("No splits provided for extraction.");
+            }
+
+            List<List<int>> expandedPageIndexes = [];
+            expandedPageIndexes.AddRange(splits.Select(split => ExpandRange(split[0], split[1])));
+            return (SplitFiles)pdfExtractor.ExtractSubDocuments(expandedPageIndexes);
+        }
+    }
+}

--- a/src/Mindee/V2/FileOperations/Split.cs
+++ b/src/Mindee/V2/FileOperations/Split.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Mindee.Exceptions;
 using Mindee.Extraction;
 using Mindee.Input;
+using Mindee.Pdf;
 
 namespace Mindee.V2.FileOperations
 {
@@ -35,12 +37,22 @@ namespace Mindee.V2.FileOperations
         }
 
         /// <summary>
-        ///
+        /// Initializes an instance of a Split operation.
+        /// Transforms images to PDFs if necessary.
         /// </summary>
         /// <param name="inputSource"></param>
         public Split(LocalInputSource inputSource)
         {
-            this._localInput = inputSource;
+            if (inputSource.IsPdf())
+            {
+                _localInput = inputSource;
+            }
+            else
+            {
+                byte[] pdfBytes = PdfUtils.ConvertImageToPdf(inputSource.FileBytes, inputSource.Filename);
+                string newFilename = Path.ChangeExtension(inputSource.Filename, ".pdf");
+                _localInput = new LocalInputSource(pdfBytes, newFilename);
+            }
         }
 
         /// <summary>
@@ -58,7 +70,7 @@ namespace Mindee.V2.FileOperations
 
             List<List<int>> expandedPageIndexes = [];
             expandedPageIndexes.AddRange(splits.Select(split => ExpandRange(split[0], split[1])));
-            return (SplitFiles)pdfExtractor.ExtractSubDocuments(expandedPageIndexes);
+            return new SplitFiles(pdfExtractor.ExtractSubDocuments(expandedPageIndexes));
         }
     }
 }

--- a/src/Mindee/V2/FileOperations/SplitFiles.cs
+++ b/src/Mindee/V2/FileOperations/SplitFiles.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.IO;
+using Mindee.Pdf;
+
+namespace Mindee.V2.FileOperations
+{
+    /// <summary>
+    /// Collection of split PDFs.
+    /// </summary>
+    public sealed class SplitFiles : List<ExtractedPdf>
+    {
+        /// <summary>
+        /// Saves all the extracted pages to disk.
+        /// </summary>
+        /// <param name="path">Path for all files</param>
+        /// <param name="prefix">Prefix for file names</param>
+        public void SaveAllToDisk(string path, string prefix = "split")
+        {
+            Directory.CreateDirectory(path);
+
+            int index = 1;
+            foreach (var crop in this)
+            {
+                string fileName = $"{prefix}_{index:D3}.pdf";
+                string filePath = Path.Combine(path, fileName);
+
+                crop.WriteToFile(filePath);
+
+                index++;
+            }
+        }
+    }
+}

--- a/src/Mindee/V2/FileOperations/SplitFiles.cs
+++ b/src/Mindee/V2/FileOperations/SplitFiles.cs
@@ -10,6 +10,21 @@ namespace Mindee.V2.FileOperations
     public sealed class SplitFiles : List<ExtractedPdf>
     {
         /// <summary>
+        ///
+        /// </summary>
+        /// <param name="collection"></param>
+        public SplitFiles(IEnumerable<ExtractedPdf> collection) : base(collection)
+        {
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public SplitFiles() : base()
+        {
+        }
+
+        /// <summary>
         /// Saves all the extracted pages to disk.
         /// </summary>
         /// <param name="path">Path for all files</param>

--- a/src/Mindee/V2/Product/Crop/CropItem.cs
+++ b/src/Mindee/V2/Product/Crop/CropItem.cs
@@ -1,4 +1,9 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Mindee.Extraction;
+using Mindee.Geometry;
+using Mindee.Image;
+using Mindee.Input;
 using Mindee.V2.Parsing.Inference.Field;
 
 namespace Mindee.V2.Product.Crop
@@ -27,6 +32,17 @@ namespace Mindee.V2.Product.Crop
         public override string ToString()
         {
             return $"* :Location: {Location}\n  :Object Type: {ObjectType}";
+        }
+
+        /// <summary>
+        /// Extract the crop from the source document.
+        /// </summary>
+        /// <param name="inputSource"></param>
+        /// <returns></returns>
+        public ExtractedImage ExtractFromFile(LocalInputSource inputSource)
+        {
+            var crop = new FileOperations.Crop(inputSource);
+            return crop.ExtractSingleCrop(this);
         }
     }
 }

--- a/src/Mindee/V2/Product/Split/SplitRange.cs
+++ b/src/Mindee/V2/Product/Split/SplitRange.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Mindee.Input;
+using Mindee.Pdf;
 
 namespace Mindee.V2.Product.Split
 {
@@ -28,6 +30,17 @@ namespace Mindee.V2.Product.Split
         {
             string pageRange = string.Join(",", PageRange);
             return $"* :Page Range: {pageRange}\n  :Document Type: {DocumentType}";
+        }
+
+        /// <summary>
+        /// Extracts the split from the source document.
+        /// </summary>
+        /// <param name="inputSource"></param>
+        /// <returns></returns>
+        public ExtractedPdf ExtractFromFile(LocalInputSource inputSource)
+        {
+            var split = new FileOperations.Split(inputSource);
+            return split.ExtractSingleSplit(this);
         }
     }
 }

--- a/tests/Mindee.IntegrationTests/V1/InvoiceSplitterAutoExtractionTest.cs
+++ b/tests/Mindee.IntegrationTests/V1/InvoiceSplitterAutoExtractionTest.cs
@@ -1,6 +1,6 @@
 using Mindee.Input;
 using Mindee.Pdf;
-using Mindee.V1.Extraction;
+using Mindee.V1.Image;
 using Mindee.V1.Parsing.Common;
 using Mindee.V1.Product.Invoice;
 using Mindee.V1.Product.InvoiceSplitter;

--- a/tests/Mindee.IntegrationTests/V2/FileOperations/CropTest.cs
+++ b/tests/Mindee.IntegrationTests/V2/FileOperations/CropTest.cs
@@ -80,10 +80,10 @@ namespace Mindee.IntegrationTests.V2.FileOperations
             extractedImages.SaveAllToDisk(_outputDir, 50);
 
             var file1Info = new FileInfo(Path.Combine(_outputDir, "crop_001.jpg"));
-            Assert.InRange(file1Info.Length, 100000, 110000);
+            Assert.InRange(file1Info.Length, 99000, 110000);
 
             var file2Info = new FileInfo(Path.Combine(_outputDir, "crop_002.jpg"));
-            Assert.InRange(file2Info.Length, 100000, 110000);
+            Assert.InRange(file2Info.Length, 99000, 110000);
         }
 
         [Fact(Timeout = 180000)]

--- a/tests/Mindee.IntegrationTests/V2/FileOperations/CropTest.cs
+++ b/tests/Mindee.IntegrationTests/V2/FileOperations/CropTest.cs
@@ -1,0 +1,89 @@
+using Mindee.Input;
+using Mindee.V2;
+using Mindee.V2.FileOperations;
+using Mindee.V2.Product.Crop;
+using Mindee.V2.Product.Crop.Params;
+using Mindee.V2.Product.Extraction;
+using Mindee.V2.Product.Extraction.Params;
+
+namespace Mindee.IntegrationTests.V2.FileOperations
+{
+    [Trait("Category", "V2")]
+    [Trait("Category", "FileOperations")]
+    public class CropTest : IDisposable
+    {
+        private readonly string? _cropModelId;
+        private readonly string? _findocModelId;
+        private readonly Client _client;
+        private readonly string _outputDir;
+
+        public CropTest()
+        {
+            var apiKey = Environment.GetEnvironmentVariable("MindeeV2__ApiKey");
+            _client = TestingUtilities.GetOrGenerateMindeeClientV2(apiKey);
+            _cropModelId = Environment.GetEnvironmentVariable("MindeeV2__Crop__Model__Id");
+            _findocModelId = Environment.GetEnvironmentVariable("MindeeV2__Findoc__Model__Id");
+
+            _outputDir = Path.Combine(Directory.GetCurrentDirectory(), "output");
+            if (!Directory.Exists(_outputDir))
+            {
+                Directory.CreateDirectory(_outputDir);
+            }
+        }
+
+        public void Dispose()
+        {
+            var file1 = Path.Combine(_outputDir, "crop_001.jpg");
+            var file2 = Path.Combine(_outputDir, "crop_002.jpg");
+
+            if (File.Exists(file1)) File.Delete(file1);
+            if (File.Exists(file2)) File.Delete(file2);
+        }
+
+        private void CheckFindocReturn(ExtractionResponse findocResponse)
+        {
+            Assert.True(findocResponse.Inference.Model.Id.Length > 0);
+
+            var totalAmount = findocResponse.Inference.Result.Fields["total_amount"].SimpleField;
+            Assert.NotNull(totalAmount);
+            Assert.True(totalAmount.Value > 0);
+        }
+
+        [Fact(Timeout = 180000)]
+        public async Task Extract_Crops_From_Image_Correctly()
+        {
+            var inputSource = new LocalInputSource(
+                Constants.V2ProductDir + "crop/default_sample.jpg");
+            var cropParams = new CropParameters(_cropModelId);
+
+            var response = await _client.EnqueueAndGetResultAsync<CropResponse>(
+                inputSource, cropParams);
+
+            Assert.NotNull(response);
+            Assert.Equal(2, response.Inference.Result.Crops.Count);
+
+            var cropOperation = new Crop(inputSource);
+            var extractedImages = cropOperation.ExtractCrops(response.Inference.Result.Crops);
+
+            Assert.Equal(2, extractedImages.Count);
+            Assert.Equal("default_sample.jpg_page0-0.jpg", extractedImages[0].Filename);
+            Assert.Equal("default_sample.jpg_page0-1.jpg", extractedImages[1].Filename);
+
+            var extractionInput = extractedImages[0].AsInputSource();
+            var findocParams = new ExtractionParameters(_findocModelId);
+
+            var invoice0 = await _client.EnqueueAndGetResultAsync<ExtractionResponse>(
+                extractionInput, findocParams);
+
+            CheckFindocReturn(invoice0);
+
+            extractedImages.SaveAllToDisk(_outputDir, 50);
+
+            var file1Info = new FileInfo(Path.Combine(_outputDir, "crop_001.jpg"));
+            Assert.InRange(file1Info.Length, 100000, 110000);
+
+            var file2Info = new FileInfo(Path.Combine(_outputDir, "crop_002.jpg"));
+            Assert.InRange(file2Info.Length, 100000, 110000);
+        }
+    }
+}

--- a/tests/Mindee.IntegrationTests/V2/FileOperations/CropTest.cs
+++ b/tests/Mindee.IntegrationTests/V2/FileOperations/CropTest.cs
@@ -52,8 +52,8 @@ namespace Mindee.IntegrationTests.V2.FileOperations
         [Fact(Timeout = 180000)]
         public async Task Extract_Crops_From_Image_Correctly()
         {
-            var inputSource = new LocalInputSource(
-                Constants.V2ProductDir + "crop/default_sample.jpg");
+            var inputSource = new LocalInputSource(Path.Combine(
+                Constants.V2ProductDir, "crop/default_sample.jpg"));
             var cropParams = new CropParameters(_cropModelId);
 
             var response = await _client.EnqueueAndGetResultAsync<CropResponse>(
@@ -84,6 +84,25 @@ namespace Mindee.IntegrationTests.V2.FileOperations
 
             var file2Info = new FileInfo(Path.Combine(_outputDir, "crop_002.jpg"));
             Assert.InRange(file2Info.Length, 100000, 110000);
+        }
+
+        [Fact(Timeout = 180000)]
+        public async Task Extract_Crops_From_Each_Pdf_Page_Correctly()
+        {
+
+            var inputSource = new LocalInputSource(
+                new FileInfo(Path.Combine(Constants.V2ProductDir, "multipage_sample.pdf")));
+
+            var cropParams = new CropParameters(_cropModelId);
+
+            var response = await _client.EnqueueAndGetResultAsync<CropResponse>(
+                inputSource, cropParams);
+            var cropOperation = new Crop(inputSource);
+            var extractedImages = cropOperation.ExtractCrops(response.Inference.Result.Crops);
+
+            Assert.Equal(2, extractedImages.Count);
+            Assert.Equal("default_sample.jpg_page0-0.jpg", extractedImages[0].Filename);
+            Assert.Equal("default_sample.jpg_page1-0.jpg", extractedImages[1].Filename);
         }
     }
 }

--- a/tests/Mindee.IntegrationTests/V2/FileOperations/CropTest.cs
+++ b/tests/Mindee.IntegrationTests/V2/FileOperations/CropTest.cs
@@ -91,7 +91,7 @@ namespace Mindee.IntegrationTests.V2.FileOperations
         {
 
             var inputSource = new LocalInputSource(
-                new FileInfo(Path.Combine(Constants.V2ProductDir, "multipage_sample.pdf")));
+                new FileInfo(Path.Combine(Constants.V2ProductDir, "crop/multipage_sample.pdf")));
 
             var cropParams = new CropParameters(_cropModelId);
 

--- a/tests/Mindee.IntegrationTests/V2/FileOperations/CropTest.cs
+++ b/tests/Mindee.IntegrationTests/V2/FileOperations/CropTest.cs
@@ -100,9 +100,9 @@ namespace Mindee.IntegrationTests.V2.FileOperations
             var cropOperation = new Crop(inputSource);
             var extractedImages = cropOperation.ExtractCrops(response.Inference.Result.Crops);
 
-            Assert.Equal(2, extractedImages.Count);
-            Assert.Equal("default_sample.jpg_page0-0.jpg", extractedImages[0].Filename);
-            Assert.Equal("default_sample.jpg_page1-0.jpg", extractedImages[1].Filename);
+            Assert.Equal(5, extractedImages.Count);
+            Assert.Equal("multipage_sample.pdf_page0-0.jpg", extractedImages[0].Filename);
+            Assert.Equal("multipage_sample.pdf_page1-0.jpg", extractedImages[3].Filename);
         }
     }
 }

--- a/tests/Mindee.IntegrationTests/V2/FileOperations/SplitTest.cs
+++ b/tests/Mindee.IntegrationTests/V2/FileOperations/SplitTest.cs
@@ -1,0 +1,97 @@
+using Mindee.Input;
+using Mindee.V2;
+using Mindee.V2.FileOperations;
+using Mindee.V2.Product.Extraction;
+using Mindee.V2.Product.Extraction.Params;
+using Mindee.V2.Product.Split;
+using Mindee.V2.Product.Split.Params;
+
+namespace Mindee.IntegrationTests.V2.FileOperations
+{
+    [Trait("Category", "V2")]
+    [Trait("Category", "FileOperations")]
+    public class SplitTest : IDisposable
+    {
+        private readonly string? _splitModelId;
+        private readonly string? _findocModelId;
+        private readonly Client _client;
+        private readonly string _outputDir;
+
+        public SplitTest()
+        {
+            var apiKey = Environment.GetEnvironmentVariable("MindeeV2__ApiKey");
+            _client = TestingUtilities.GetOrGenerateMindeeClientV2(apiKey);
+            _splitModelId = Environment.GetEnvironmentVariable("MindeeV2__Split__Model__Id");
+            _findocModelId = Environment.GetEnvironmentVariable("MindeeV2__Findoc__Model__Id");
+
+            _outputDir = Path.Combine(Directory.GetCurrentDirectory(), "output");
+            if (!Directory.Exists(_outputDir))
+            {
+                Directory.CreateDirectory(_outputDir);
+            }
+        }
+
+        public void Dispose()
+        {
+            var file1 = Path.Combine(_outputDir, "split_001.pdf");
+            var file2 = Path.Combine(_outputDir, "split_002.pdf");
+
+            if (File.Exists(file1)) File.Delete(file1);
+            if (File.Exists(file2)) File.Delete(file2);
+        }
+
+        private void CheckFindocReturn(ExtractionResponse findocResponse)
+        {
+            Assert.True(findocResponse.Inference.Model.Id.Length > 0);
+
+            var totalAmount = findocResponse.Inference.Result.Fields["total_amount"].SimpleField;
+            Assert.NotNull(totalAmount);
+            Assert.True(totalAmount.Value > 0);
+        }
+
+        [Fact(Timeout = 180000)]
+        public async Task Extract_Splits_From_Pdf_Correctly()
+        {
+            var inputSource = new LocalInputSource(
+                Constants.V2ProductDir + "split/default_sample.pdf");
+            var splitParams = new SplitParameters(_splitModelId);
+
+            var response = await _client.EnqueueAndGetResultAsync<SplitResponse>(
+                inputSource, splitParams);
+
+            Assert.NotNull(response);
+            Assert.Equal(2, response.Inference.Result.Splits.Count);
+
+            var splitOperation = new Split(inputSource);
+            var extractedSplits = splitOperation.ExtractSplits(
+                response.Inference.Result.Splits.Select(s => s.PageRange).ToList());
+
+            Assert.Equal(2, extractedSplits.Count);
+            Assert.Equal("default_sample_001-001.pdf", extractedSplits[0].Filename);
+            Assert.Equal("default_sample_002-002.pdf", extractedSplits[1].Filename);
+
+            var extractionInput = extractedSplits[0].AsInputSource();
+            var findocParams = new ExtractionParameters(_findocModelId);
+
+            var invoice0 = await _client.EnqueueAndGetResultAsync<ExtractionResponse>(
+                extractionInput, findocParams);
+
+            CheckFindocReturn(invoice0);
+
+            extractedSplits.SaveAllToDisk(_outputDir);
+
+            for (int i = 0; i < extractedSplits.Count; i++)
+            {
+                var fileName = $"split_{i + 1:D3}.pdf";
+                var filePath = Path.Combine(_outputDir, fileName);
+                var fileInfo = new FileInfo(filePath);
+
+                Assert.True(fileInfo.Exists);
+                Assert.True(fileInfo.Length > 0);
+
+                var localInput = new LocalInputSource(fileInfo);
+                Assert.Equal(extractedSplits[i].PageCount, localInput.GetPageCount());
+            }
+        }
+    }
+}

--- a/tests/Mindee.UnitTests/Extraction/ImageExtractorTest.cs
+++ b/tests/Mindee.UnitTests/Extraction/ImageExtractorTest.cs
@@ -1,5 +1,5 @@
 using Mindee.Input;
-using Mindee.V1.Extraction;
+using Mindee.V1.Image;
 using Mindee.V1.Parsing.Common;
 using Mindee.V1.Product.BarcodeReader;
 using Mindee.V1.Product.MultiReceiptsDetector;

--- a/tests/Mindee.UnitTests/Extraction/PdfExtractorTest.cs
+++ b/tests/Mindee.UnitTests/Extraction/PdfExtractorTest.cs
@@ -1,5 +1,5 @@
 using Mindee.Input;
-using Mindee.V1.Extraction;
+using Mindee.V1.Image;
 using Mindee.V1.Parsing.Common;
 using Mindee.V1.Product.InvoiceSplitter;
 

--- a/tests/Mindee.UnitTests/V2/FileOperations/CropTest.cs
+++ b/tests/Mindee.UnitTests/V2/FileOperations/CropTest.cs
@@ -1,0 +1,67 @@
+using Mindee.Input;
+using Mindee.V2.FileOperations;
+using Mindee.V2.Parsing;
+using Mindee.V2.Product.Crop;
+
+namespace Mindee.UnitTests.V2.FileOperations
+{
+    [Trait("Category", "V2")]
+    [Trait("Category", "FileOperations")]
+    public class CropTest
+    {
+        private readonly string _cropDataDir = Path.Combine(Constants.V2RootDir, "products", "crop");
+
+        [Fact]
+        public void Processes_SinglePage_CropSplit_Correctly()
+        {
+            var inputSample = new LocalInputSource(
+                new FileInfo(Path.Combine(_cropDataDir, "default_sample.jpg")));
+
+            var localResponse = new LocalResponse(
+                new FileInfo(Path.Combine(_cropDataDir, "crop_single.json")));
+            var doc = localResponse.DeserializeResponse<CropResponse>();
+
+            var cropOperation = new Crop(inputSample);
+            var extractedCrops = cropOperation.ExtractCrops(doc.Inference.Result.Crops);
+
+            Assert.Single(extractedCrops);
+
+            Assert.Equal(0, extractedCrops[0].PageId);
+            Assert.Equal(0, extractedCrops[0].ElementId);
+
+            using var bitmap0 = extractedCrops[0].Image;
+            Assert.Equal(2822, bitmap0.Width);
+            Assert.Equal(1572, bitmap0.Height);
+        }
+
+        [Fact]
+        public void Processes_MultiPage_ReceiptSplit_Correctly()
+        {
+            var inputSample = new LocalInputSource(
+                new FileInfo(Path.Combine(_cropDataDir, "multipage_sample.pdf")));
+
+            var localResponse = new LocalResponse(
+                new FileInfo(Path.Combine(_cropDataDir, "crop_multiple.json")));
+            var doc = localResponse.DeserializeResponse<CropResponse>();
+
+            var cropOperation = new Crop(inputSample);
+            var extractedCrops = cropOperation.ExtractCrops(doc.Inference.Result.Crops);
+
+            Assert.Equal(2, extractedCrops.Count);
+
+            Assert.Equal(0, extractedCrops[0].PageId);
+            Assert.Equal(0, extractedCrops[0].ElementId);
+
+            using var bitmap0 = extractedCrops[0].Image;
+            Assert.Equal(156, bitmap0.Width);
+            Assert.Equal(757, bitmap0.Height);
+
+            Assert.Equal(0, extractedCrops[1].PageId);
+            Assert.Equal(1, extractedCrops[1].ElementId);
+
+            using var bitmap1 = extractedCrops[1].Image;
+            Assert.Equal(188, bitmap1.Width);
+            Assert.Equal(691, bitmap1.Height);
+        }
+    }
+}

--- a/tests/Mindee.UnitTests/V2/FileOperations/SplitTest.cs
+++ b/tests/Mindee.UnitTests/V2/FileOperations/SplitTest.cs
@@ -1,0 +1,55 @@
+using Mindee.Input;
+using Mindee.V2.FileOperations;
+using Mindee.V2.Parsing;
+using Mindee.V2.Product.Split;
+
+namespace Mindee.UnitTests.V2.FileOperations
+{
+    [Trait("Category", "V2")]
+    [Trait("Category", "FileOperations")]
+    public class SplitTest
+    {
+        private readonly string _splitDataDir = Path.Combine(Constants.V2RootDir, "products", "split");
+        private readonly string _finDocDataDir = Path.Combine(Constants.V2RootDir, "products", "extraction", "financial_document");
+
+        [Fact]
+        public void Processes_SinglePage_Split_Correctly()
+        {
+            var inputSample = new LocalInputSource(
+                new FileInfo(Path.Combine(_finDocDataDir, "default_sample.jpg")));
+
+            var localResponse = new LocalResponse(
+                new FileInfo(Path.Combine(_splitDataDir, "split_single.json")));
+            var doc = localResponse.DeserializeResponse<SplitResponse>();
+
+            var splitOperation = new Split(inputSample);
+            List<SplitRange> splits = doc.Inference.Result.Splits;
+            var extractedSplits = splitOperation.ExtractSplits(splits.Select(s => s.PageRange).ToList());
+
+            Assert.Single(extractedSplits);
+
+            Assert.Equal(1, extractedSplits[0].PageCount);
+        }
+
+        [Fact]
+        public void Processes_MultiPage_ReceiptSplit_Correctly()
+        {
+            var inputSample = new LocalInputSource(
+                new FileInfo(Path.Combine(_splitDataDir, "invoice_5p.pdf")));
+
+            var localResponse = new LocalResponse(
+                new FileInfo(Path.Combine(_splitDataDir, "split_multiple.json")));
+            var doc = localResponse.DeserializeResponse<SplitResponse>();
+
+            var splitOperation = new Split(inputSample);
+            List<SplitRange> splits = doc.Inference.Result.Splits;
+            var extractedSplits = splitOperation.ExtractSplits(splits.Select(s => s.PageRange).ToList());
+
+            Assert.Equal(3, extractedSplits.Count);
+
+            Assert.Equal(1, extractedSplits[0].PageCount);
+            Assert.Equal(3, extractedSplits[1].PageCount);
+            Assert.Equal(1, extractedSplits[2].PageCount);
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
* :sparkles: add support for crop and split file operations
* :sparkles: add support for generic adapters in ImageExtractor and PdfExtractor
* :sparkles: add ability to set quality during ImageExtractor save and inputsource conversion operations
* :recycle: move common logic of extractors to main `Extractor` namespace
* :bug: fix PdfExtractor improperly loading some files
* :bug: fix generated file names trying to target folders when trying to save to specific files

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
