### PR TITLE
:white_check_mark: allow logging of detailled errors

### DIFF
--- a/src/Mindee/V2/Http/HttpApiV2.cs
+++ b/src/Mindee/V2/Http/HttpApiV2.cs
@@ -113,11 +113,16 @@ namespace Mindee.V2.Http
             {
                 if (responseContent == null || !responseContent.Contains("\"status\":"))
                 {
+                    Logger?.LogInformation("Empty response from server.");
                     return MakeUnknownError(statusCode, responseContent);
                 }
 
                 var error = JsonSerializer.Deserialize<ErrorResponse>(responseContent);
-                return error ?? MakeUnknownError(statusCode, responseContent);
+                if (error == null)
+                    return MakeUnknownError(statusCode, responseContent);
+
+                Logger?.LogInformation("{Response}", error);
+                return error;
             }
             catch (JsonException)
             {

--- a/src/Mindee/V2/Parsing/ErrorResponse.cs
+++ b/src/Mindee/V2/Parsing/ErrorResponse.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace Mindee.V2.Parsing
@@ -6,8 +7,13 @@ namespace Mindee.V2.Parsing
     /// <summary>
     ///     Error response detailing a problem. The format adheres to RFC 9457.
     /// </summary>
-    public class ErrorResponse : IErrorResponse
+    public class ErrorResponse : BaseResponse, IErrorResponse
     {
+        /// <summary>
+        /// Empty constructor.
+        /// </summary>
+        public ErrorResponse() { }
+
         /// <summary>
         ///     Constructor with all attributes.
         /// </summary>
@@ -45,7 +51,34 @@ namespace Mindee.V2.Parsing
         /// </summary>
         public override string ToString()
         {
-            return "HTTP Status: " + Status + " - " + Detail;
+            var result = new System.Text.StringBuilder();
+
+            result.AppendLine("Error Details");
+            result.AppendLine("=============");
+
+            result.AppendLine($":HTTP Status: {Status}");
+            result.AppendLine($":Title: {Title}");
+            result.AppendLine($":Code: {Code}");
+            result.AppendLine($":Detail: {Detail}");
+
+            if (Errors != null && Errors.Count > 0)
+            {
+                result.AppendLine();
+                result.AppendLine("Error Items");
+                result.AppendLine("-----------");
+
+                foreach (var (error, i) in Errors.Select((error, i) => (error, i)))
+                {
+                    result.AppendLine($"**Error {i + 1}:**");
+                    result.AppendLine($"  :Pointer: {error.Pointer}");
+                    result.AppendLine($"  :Detail: {error.Detail}");
+
+                    if (i < Errors.Count - 1)
+                        result.AppendLine();
+                }
+            }
+
+            return result.ToString();
         }
     }
 }

--- a/tests/Mindee.IntegrationTests/TestingUtilities.cs
+++ b/tests/Mindee.IntegrationTests/TestingUtilities.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 // ReSharper disable once RedundantUsingDirective
 using Mindee.Extensions.DependencyInjection;
@@ -59,7 +60,7 @@ namespace Mindee.IntegrationTests
         /// </summary>
         /// <param name="apiKey">The API key for mindee.</param>
         /// <returns>A valid Mindee client instance.</returns>
-        public static ClientV1 GetOrGenerateMindeeClient(string? apiKey)
+        public static ClientV1 GetOrGenerateMindeeClientV1(string? apiKey)
         {
             if (_mindeeClient != null)
             {
@@ -71,7 +72,7 @@ namespace Mindee.IntegrationTests
             {
                 options.ApiKey = apiKey;
             }, true);
-            return _mindeeClient ??= new ClientV1(apiKey);
+            return _mindeeClient ??= new ClientV1(apiKey: apiKey);
         }
 
         /// <summary>
@@ -87,15 +88,18 @@ namespace Mindee.IntegrationTests
             }
 
             var serviceCollection = new ServiceCollection();
-            var loggerFactory = NullLoggerFactory.Instance; // Use the factory
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.SetMinimumLevel(LogLevel.Information);
+                builder.AddConsole();
+            });
 
             serviceCollection.AddMindeeApiV2(options =>
             {
                 options.ApiKey = apiKey;
             }, loggerFactory, true);
 
-            // Pass the loggerFactory as the second parameter to the ClientV2 constructor
-            return _mindeeClientV2 ??= new ClientV2(apiKey, loggerFactory);
+            return _mindeeClientV2 ??= new ClientV2(apiKey: apiKey, loggerFactory: loggerFactory);
         }
 
         /// <summary>

--- a/tests/Mindee.IntegrationTests/V1/ClientTest.cs
+++ b/tests/Mindee.IntegrationTests/V1/ClientTest.cs
@@ -22,7 +22,7 @@ namespace Mindee.IntegrationTests.V1
         public ClientTest()
         {
             var apiKey = Environment.GetEnvironmentVariable("Mindee__ApiKey");
-            _client = TestingUtilities.GetOrGenerateMindeeClient(apiKey);
+            _client = TestingUtilities.GetOrGenerateMindeeClientV1(apiKey);
         }
 
         [Fact(Timeout = 180000)]

--- a/tests/Mindee.IntegrationTests/V1/Input/UrlInputSourceTest.cs
+++ b/tests/Mindee.IntegrationTests/V1/Input/UrlInputSourceTest.cs
@@ -12,7 +12,7 @@ namespace Mindee.IntegrationTests.V1.Input
         {
             var apiKey = Environment.GetEnvironmentVariable("Mindee__ApiKey");
             var blankUrl = Environment.GetEnvironmentVariable("MindeeV2__Blank__Pdf__Url");
-            var client = TestingUtilities.GetOrGenerateMindeeClient(apiKey);
+            var client = TestingUtilities.GetOrGenerateMindeeClientV1(apiKey);
             var remoteInput =
                 new UrlInputSource(
                     blankUrl);

--- a/tests/Mindee.IntegrationTests/V1/InvoiceSplitterAutoExtractionTest.cs
+++ b/tests/Mindee.IntegrationTests/V1/InvoiceSplitterAutoExtractionTest.cs
@@ -26,7 +26,7 @@ namespace Mindee.IntegrationTests.V1
         public async Task GivenAPdf_ShouldExtractInvoicesStrict_MustSucceed()
         {
             var apiKey = Environment.GetEnvironmentVariable("Mindee__ApiKey");
-            var client = TestingUtilities.GetOrGenerateMindeeClient(apiKey);
+            var client = TestingUtilities.GetOrGenerateMindeeClientV1(apiKey);
             var invoiceSplitterBytes =
                 File.ReadAllBytes(Constants.V1ProductDir + "invoice_splitter/default_sample.pdf");
             var invoiceSplitterInputSource = new LocalInputSource(invoiceSplitterBytes, "default_sample.pdf");

--- a/tests/Mindee.IntegrationTests/V1/Workflow/WorkflowTest.cs
+++ b/tests/Mindee.IntegrationTests/V1/Workflow/WorkflowTest.cs
@@ -18,7 +18,7 @@ namespace Mindee.IntegrationTests.V1.Workflow
         public WorkflowTest()
         {
             var apiKey1 = Environment.GetEnvironmentVariable("Mindee__ApiKey");
-            _client = TestingUtilities.GetOrGenerateMindeeClient(apiKey1);
+            _client = TestingUtilities.GetOrGenerateMindeeClientV1(apiKey1);
             _ragMatchInputSource = new LocalInputSource(
                 Constants.V1ProductDir + "financial_document/default_sample.jpg");
             _ragNoMatchInputSource = new LocalInputSource(

--- a/tests/Mindee.UnitTests/UnitTestBase.cs
+++ b/tests/Mindee.UnitTests/UnitTestBase.cs
@@ -32,6 +32,15 @@ namespace Mindee.UnitTests
                 rag: false);
         }
 
+        /// <summary>
+        ///     Ensures all line endings are identical before comparison so the test
+        ///     behaves the same on every platform (LF vs CRLF).
+        /// </summary>
+        public static string NormalizeLineEndings(string input)
+        {
+            return input.Replace("\r\n", "\n").Replace("\r", "\n");
+        }
+
         public static ServiceProvider InitServiceProviderV1(HttpStatusCode statusCode, string fileContent)
         {
             var services = new ServiceCollection();

--- a/tests/Mindee.UnitTests/V2/Parsing/ErrorResponseTest.cs
+++ b/tests/Mindee.UnitTests/V2/Parsing/ErrorResponseTest.cs
@@ -1,0 +1,25 @@
+using Mindee.V2.Parsing;
+
+namespace Mindee.UnitTests.V2.Parsing
+{
+    public class ErrorResponseTest
+    {
+        [Fact]
+        public void RstOutput_mustBeValid()
+        {
+            var localResponse = new LocalResponse(
+                File.ReadAllText(Constants.V2RootDir + "errors/error_422_invalid_fields.json"));
+            var response = localResponse.DeserializeResponse<ErrorResponse>();
+
+            var rstOutput = File.ReadAllText(
+                Constants.V2RootDir + "errors/error_422_invalid_fields.rst");
+
+            Assert.NotNull(response);
+
+            Assert.Equal(
+                UnitTestBase.NormalizeLineEndings(rstOutput),
+                UnitTestBase.NormalizeLineEndings(response.ToString())
+            );
+        }
+    }
+}

--- a/tests/Mindee.UnitTests/V2/Product/ExtractionTest.cs
+++ b/tests/Mindee.UnitTests/V2/Product/ExtractionTest.cs
@@ -25,7 +25,7 @@ namespace Mindee.UnitTests.V2.Product
         [Fact]
         public void FinancialDocument_WhenEmpty_MustHaveValidProperties()
         {
-            var response = GetInference("extraction/financial_document/blank.json");
+            var response = GetResponse("extraction/financial_document/blank.json");
             AssertInferenceResponse(response);
 
             var fields = response.Inference.Result.Fields;
@@ -64,7 +64,7 @@ namespace Mindee.UnitTests.V2.Product
         [Fact]
         public void FinancialDocument_WhenComplete_MustHaveValidProperties()
         {
-            var response = GetInference("extraction/financial_document/complete.json");
+            var response = GetResponse("extraction/financial_document/complete.json");
             AssertInferenceResponse(response);
 
             var activeOptions = response.Inference.ActiveOptions;
@@ -97,10 +97,10 @@ namespace Mindee.UnitTests.V2.Product
         }
 
 
-        [Fact(DisplayName = "deep_nested_fields.json – all nested structures must be typed correctly")]
+        [Fact]
         public void DeepNestedFields_mustExposeCorrectTypes()
         {
-            var response = GetInference("extraction/deep_nested_fields.json");
+            var response = GetResponse("extraction/deep_nested_fields.json");
             AssertInferenceResponse(response);
 
             var inference = response.Inference;
@@ -134,10 +134,10 @@ namespace Mindee.UnitTests.V2.Product
             Assert.Equal("value_9", deepSimple.Value);
         }
 
-        [Fact(DisplayName = "standard_field_types.json – file metadata must be recognised")]
+        [Fact]
         public void StandardFieldTypes_mustExposeFileValues()
         {
-            var response = GetInference("extraction/standard_field_types.json");
+            var response = GetResponse("extraction/standard_field_types.json");
             AssertInferenceResponse(response);
 
             var inference = response.Inference;
@@ -156,10 +156,10 @@ namespace Mindee.UnitTests.V2.Product
             Assert.Null(alias);
         }
 
-        [Fact(DisplayName = "standard_field_types.json – simple fields must be recognised")]
+        [Fact]
         public void StandardFieldTypes_mustExposeSimpleFieldValues()
         {
-            var response = GetInference("extraction/standard_field_types.json");
+            var response = GetResponse("extraction/standard_field_types.json");
             AssertInferenceResponse(response);
 
             var inference = response.Inference;
@@ -197,10 +197,10 @@ namespace Mindee.UnitTests.V2.Product
             Assert.Null(fields["field_simple_null"].SimpleField.Confidence);
         }
 
-        [Fact(DisplayName = "standard_field_types.json – simple list fields must be recognised")]
+        [Fact]
         public void StandardFieldTypes_mustExposeSimpleListFieldValues()
         {
-            var response = GetInference("extraction/standard_field_types.json");
+            var response = GetResponse("extraction/standard_field_types.json");
             AssertInferenceResponse(response);
 
             var inference = response.Inference;
@@ -219,10 +219,10 @@ namespace Mindee.UnitTests.V2.Product
             }
         }
 
-        [Fact(DisplayName = "standard_field_types.json – object fields must be recognised")]
+        [Fact]
         public void StandardFieldTypes_mustExposeObjectFieldValues()
         {
-            var response = GetInference("extraction/standard_field_types.json");
+            var response = GetResponse("extraction/standard_field_types.json");
             AssertInferenceResponse(response);
 
             var inference = response.Inference;
@@ -244,10 +244,10 @@ namespace Mindee.UnitTests.V2.Product
             }
         }
 
-        [Fact(DisplayName = "standard_field_types.json – simple list fields must be recognised")]
+        [Fact]
         public void StandardFieldTypes_mustExposeObjectListFieldValues()
         {
-            var response = GetInference("extraction/standard_field_types.json");
+            var response = GetResponse("extraction/standard_field_types.json");
             AssertInferenceResponse(response);
 
             var inference = response.Inference;
@@ -278,10 +278,10 @@ namespace Mindee.UnitTests.V2.Product
             }
         }
 
-        [Fact(DisplayName = "standard_field_types.json - locations must be recognised")]
+        [Fact]
         public void StandardFieldTypes_mustHaveLocations()
         {
-            var response = GetInference("extraction/standard_field_types.json");
+            var response = GetResponse("extraction/standard_field_types.json");
             AssertInferenceResponse(response);
 
             var inference = response.Inference;
@@ -300,27 +300,27 @@ namespace Mindee.UnitTests.V2.Product
             Assert.Equal(new Point(1, 1), polygon[3]);
         }
 
-        [Fact(DisplayName = "standard_field_types.rst – RST display must be parsed and exposed")]
-        public void RstDisplay_mustBeAccessible()
+        [Fact]
+        public void RstOutput_mustBeValid()
         {
-            var resp = GetInference("extraction/standard_field_types.json");
-            var rstReference = File.ReadAllText(
+            var response = GetResponse("extraction/standard_field_types.json");
+            var rstOutput = File.ReadAllText(
                 Constants.V2ProductDir + "extraction/standard_field_types.rst");
 
-            var inf = resp.Inference;
+            var inference = response.Inference;
 
-            Assert.NotNull(inf);
+            Assert.NotNull(inference);
 
             Assert.Equal(
-                NormalizeLineEndings(rstReference),
-                NormalizeLineEndings(inf.ToString())
+                UnitTestBase.NormalizeLineEndings(rstOutput),
+                UnitTestBase.NormalizeLineEndings(inference.ToString())
             );
         }
 
         [Fact]
         public void RawText_whenActivated_mustExposeProperties()
         {
-            var response = GetInference("extraction/raw_texts.json");
+            var response = GetResponse("extraction/raw_texts.json");
             AssertInferenceResponse(response);
 
             var activeOptions = response.Inference.ActiveOptions;
@@ -349,7 +349,7 @@ namespace Mindee.UnitTests.V2.Product
         [Fact]
         public void Rag_whenMatched_mustExposeProperties()
         {
-            var response = GetInference("extraction/rag_matched.json");
+            var response = GetResponse("extraction/rag_matched.json");
             AssertInferenceResponse(response);
 
             var activeOptions = response.Inference.ActiveOptions;
@@ -367,7 +367,7 @@ namespace Mindee.UnitTests.V2.Product
         [Fact]
         public void Rag_whenNotMatched_mustExposeProperties()
         {
-            var response = GetInference("extraction/rag_not_matched.json");
+            var response = GetResponse("extraction/rag_not_matched.json");
             AssertInferenceResponse(response);
 
             var activeOptions = response.Inference.ActiveOptions;
@@ -382,17 +382,7 @@ namespace Mindee.UnitTests.V2.Product
             Assert.Null(rag.RetrievedDocumentId);
         }
 
-        /// <summary>
-        ///     Ensures all line endings are identical before comparison so the test
-        ///     behaves the same on every platform (LF vs CRLF).
-        /// </summary>
-        private static string NormalizeLineEndings(string input)
-        {
-            return input.Replace("\r\n", "\n").Replace("\r", "\n");
-        }
-
-
-        private static ExtractionResponse GetInference(string path)
+        private static ExtractionResponse GetResponse(string path)
         {
             var localResponse = new LocalResponse(
                 File.ReadAllText(Constants.V2ProductDir + path));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

now we know WTF actually happened

```
[xUnit.net 00:00:00.09]   Starting:    Mindee.IntegrationTests
info: Mindee.V2.Client[0]
      Attempting to retrieve: 1 of 81
info: Mindee.V2.Client[0]
      Attempting to retrieve: 2 of 81
info: Mindee.V2.Http.MindeeApiV2[0]
      Parsing error response ...
info: Mindee.V2.Http.MindeeApiV2[0]
      Error Details
      =============
      :HTTP Status: 422
      :Title: Invalid fields in form
      :Code: 422-009
      :Detail: One or more fields failed validation.
      Error Items
      -----------
      **Error 1:**
        :Pointer: #/
        :Detail: Input should be a valid dictionary or object to extract fields from
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
